### PR TITLE
Streamline _hyperscript component

### DIFF
--- a/src/components/hyperscript/hyperscript.astro
+++ b/src/components/hyperscript/hyperscript.astro
@@ -24,15 +24,8 @@ const childCheckboxItems = [
           _="on click
                 set the checked of <input[type=checkbox]/> in the next <div/> to my checked
               on click from the next <div/>
-                set checked to <input[type=checkbox]:checked/> in the next <div/>
-                set unchecked to <input[type=checkbox]:not(:checked)/> in the next <div/>
-                set my indeterminate to false
-                if unchecked is empty
-                  set my checked to true
-                else if checked is empty
-                  set my checked to false
-                else
-                  set my indeterminate to true"
+                set my checked to no <input:not(:checked)/> in it
+                set my indeterminate to <:checked/> in it exists and <input:not(:checked)/> in it exists"
         />
         <label
           for={parentCheckbox.id}


### PR DESCRIPTION
There are a ton of different ways to write the same thing in _hyperscript but I think the length of the original hampers legibility somewhat. 

Arguably the setting of `checked` should also contain a `<:checked/> in it exists` to handle the case where there are actually no child checkboxes but it seems like we can skip it for this exercise? I'm not exactly sure how comprehensive you'd like these examples to be.

Happy to tweak this further though if I've dropped some considerations along the way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Simplified checkbox state management logic
	- Enhanced parent-child checkbox interaction handling
	- Streamlined control flow for checkbox selections

<!-- end of auto-generated comment: release notes by coderabbit.ai -->