### PR TITLE
Reduce Vanilla JS loc

### DIFF
--- a/src/components/vanillajs/vanillajs.astro
+++ b/src/components/vanillajs/vanillajs.astro
@@ -1,4 +1,4 @@
-<fieldset class=checkbox-container>
+<fieldset class=checkbox-demo style=border:none>
   <legend>
     <input type=checkbox id=parent-vanilla>
     <label for=parent-vanilla>Parent</label>
@@ -23,7 +23,7 @@
 </fieldset>
 
 <script is:inline>
-  for (const container of document.querySelectorAll('.checkbox-container')) {
+  for (const container of document.querySelectorAll('.checkbox-demo')) {
     const parent = container.querySelector('legend > input');
     const children = [...container.querySelectorAll('.checkbox-children input')];
 

--- a/src/components/vanillajs/vanillajs.astro
+++ b/src/components/vanillajs/vanillajs.astro
@@ -1,51 +1,41 @@
----
-const parentCheckbox = {
-	id: "parent-vanilla",
-	label: "Parent",
-};
+<fieldset class=checkbox-container>
+  <legend>
+    <input type=checkbox id=parent-vanilla>
+    <label for=parent-vanilla>Parent</label>
+  </legend>
 
-const childCheckboxItems = [
-	{ id: "child1-vanilla", label: "Child 1" },
-	{ id: "child2-vanilla", label: "Child 2" },
-	{ id: "child3-vanilla", label: "Child 3" },
-];
----
+  <div class=checkbox-children>
+    <div>
+      <input type=checkbox id=child1-vanilla>
+      <label for=child1-vanilla>Child 1</label>
+    </div>
 
-<div class="checkbox-demo" data-checkbox-container>
-  <div>
-    <input type="checkbox" id={parentCheckbox.id}>
-    <label for={parentCheckbox.id}>{parentCheckbox.label}</label>
+    <div>
+      <input type=checkbox id=child2-vanilla>
+      <label for=child2-vanilla>Child 2</label>
+    </div>
+
+    <div>
+      <input type=checkbox id=child3-vanilla>
+      <label for=child3-vanilla>Child 3</label>
+    </div>
   </div>
-
-  <div class="checkbox-children">
-    {childCheckboxItems.map(item => (
-      <div>
-        <input type="checkbox" id={item.id}>
-        <label for={item.id}>{item.label}</label>
-      </div>
-    ))}
-  </div>
-</div>
+</fieldset>
 
 <script is:inline>
-document.querySelectorAll('[data-checkbox-container]').forEach(container => {
-  const parent = container.querySelector('input:first-of-type');
-  const children = container.querySelectorAll('.checkbox-children input');
+  for (const container of document.querySelectorAll('.checkbox-container')) {
+    const parent = container.querySelector('legend > input');
+    const children = [...container.querySelectorAll('.checkbox-children input')];
 
-  function updateParent() {
-    const total = children.length;
-    const checked = [...children].filter(c => c.checked).length;
-    
-    parent.checked = checked === total;
-    parent.indeterminate = checked > 0 && checked < total;
+    parent.addEventListener('change', () => {
+      for (const child of children) child.checked = parent.checked;
+    });
+
+    for (const child of children) {
+      child.addEventListener('change', () => {
+        parent.checked = children.every(c => c.checked);
+        parent.indeterminate = !parent.checked && children.some(c => c.checked);
+      });
+    }
   }
-
-  parent.addEventListener('change', () => {
-    children.forEach(child => child.checked = parent.checked);
-  });
-
-  children.forEach(child => 
-    child.addEventListener('change', updateParent)
-  );
-});
-</script> 
+</script>

--- a/src/styles/checkbox-demo.css
+++ b/src/styles/checkbox-demo.css
@@ -2,9 +2,9 @@
 	padding: 0.5rem 0.75rem;
 }
 
-/* Any div directly wrapping a checkbox is a row -- matches parent + child rows,
+/* Any elt directly wrapping a checkbox is a row -- matches parent + child rows,
    but NOT .checkbox-children (which wraps divs, not an input). */
-.checkbox-demo div:has(> input[type="checkbox"]) {
+.checkbox-demo *:has(> input[type="checkbox"]) {
 	display: flex;
 	align-items: center;
 	gap: 0.75rem;
@@ -13,7 +13,7 @@
 	transition: background-color 0.15s ease;
 }
 
-.checkbox-demo div:has(> input[type="checkbox"]):hover {
+.checkbox-demo *:has(> input[type="checkbox"]):hover {
 	background: rgb(241 245 249);
 }
 


### PR DESCRIPTION
Re: our conversation in https://x.com/_jsolly/status/2062385309250117947

Use slightly more modern methods to reduce array operation complexity.

Also update HTML to be slightly more idiomatic. But not as important overall.