### PR TITLE
Refactor Datastar checkbox implementation to avoid a fixed checkbox count

### DIFF
--- a/src/components/datastar/datastar.astro
+++ b/src/components/datastar/datastar.astro
@@ -2,26 +2,23 @@
 
 <fieldset
   class="checkbox-demo"
-  data-signals="{ child1: false, child2: false, child3: false }"
-  data-computed:checked="($child1?1:0)+($child2?1:0)+($child3?1:0)"
-  data-computed:parent="$checked === 3"
-  data-computed:indeterminate="$checked > 0 && $checked < 3"
->
+  data-signals="{_child: Array(3).fill(false)}">
   <legend>
     <label>
       <input
         type="checkbox"
         data-ref:parent-input
-        data-bind:parent
-        data-on:change="$child1=$child2=$child3=event.target.checked"
-        data-effect="$parentInput.indeterminate = $indeterminate"
+        data-bind:_parent
+        data-on:change="$_child=Array(3).fill($_parent)"
+        data-effect="$parentInput.checked = $_child.every(Boolean);
+                     $parentInput.indeterminate=$_child.some(Boolean) && !$_child.every(Boolean)"
       /> Parent
     </label>
   </legend>
 
   <div class="checkbox-children">
-    <label><input type="checkbox" data-bind:child1 /> Child 1</label>
-    <label><input type="checkbox" data-bind:child2 /> Child 2</label>
-    <label><input type="checkbox" data-bind:child3 /> Child 3</label>
+    <label><input type="checkbox" data-bind:_child /> Child 1</label>
+    <label><input type="checkbox" data-bind:_child /> Child 2</label>
+    <label><input type="checkbox" data-bind:_child /> Child 3</label>
   </div>
 </fieldset>

--- a/src/data/framework-stats.json
+++ b/src/data/framework-stats.json
@@ -1,584 +1,584 @@
 {
-	"metadata": {
-		"lastUpdated": "2026-06-08T14:54:34.309Z",
-		"description": "Framework comparison metrics",
-		"codeComplexityVersion": "cc-1.0.0",
-		"bundleMeasurementVersion": "bm-2.0.0",
-		"metrics": {
-			"bundleSize": "Normalized implementation JavaScript payload (KiB): built chunks, external runtimes, and inline JS above baseline",
-			"sourceLines": "Line count of the implementation source file shown on each card",
-			"codeComplexity": "Deterministic 0-100 composite of size, logic, reactive, nesting, and vocabulary",
-			"vibeComplexity": "AI-judged implementation complexity on a 0-100 scale",
-			"bundleSizeZScore": "Standardized score relative to mean",
-			"codeComplexityZScore": "Standardized score relative to mean",
-			"vibeComplexityZScore": "Standardized score relative to mean"
-		}
-	},
-	"frameworks": {
-		"vanillajs": {
-			"bundleSize": 0.28,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/vanillajs",
-				"inlineJsBytes": 610,
-				"jsRequestCount": 0,
-				"jsRawBytes": 610,
-				"jsNormalizedBytes": 287,
-				"jsSources": [
-					{
-						"kind": "inline",
-						"rawBytes": 610,
-						"normalizedBytes": 287
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 610,
-				"jsImplementationNormalizedBytes": 287,
-				"jsImplementationNormalizedKiB": 0.28,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 28,
-			"codeComplexity": 54,
-			"vibeComplexity": 28,
-			"bundleSizeZScore": -1.1352337818659353,
-			"codeComplexityZScore": -0.023792669893764433,
-			"vibeComplexityZScore": -0.610312990217418,
-			"codeComplexitySubscores": {
-				"size": 18,
-				"logic": 11.6,
-				"reactive": 0,
-				"nesting": 12,
-				"vocabulary": 12
-			},
-			"codeComplexityRaw": {
-				"astNodes": 167,
-				"logicDecisions": 4,
-				"reactiveSurface": 0,
-				"maxNestingDepth": 3,
-				"distinctOperators": 21,
-				"distinctOperands": 27,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 0,
-				"stateAtoms": 0,
-				"vocabulary": 34
-			}
-		},
-		"alpine": {
-			"bundleSize": 15.64,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/alpine",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 1,
-				"jsRawBytes": 44258,
-				"jsNormalizedBytes": 16019,
-				"jsSources": [
-					{
-						"kind": "first-party",
-						"url": "/_astro/alpine.astro_astro_type_script_index_0_lang.9qxo6GKI.js",
-						"rawBytes": 44258,
-						"normalizedBytes": 16019
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 16019,
-				"jsImplementationNormalizedKiB": 15.64,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 33,
-			"codeComplexity": 55,
-			"vibeComplexity": 22,
-			"bundleSizeZScore": -0.23315458427355226,
-			"codeComplexityZScore": 0.03568900484064686,
-			"vibeComplexityZScore": -0.8718757003105971,
-			"codeComplexitySubscores": {
-				"size": 13.6,
-				"logic": 5,
-				"reactive": 8,
-				"nesting": 18,
-				"vocabulary": 10.4
-			},
-			"codeComplexityRaw": {
-				"astNodes": 92,
-				"logicDecisions": 1,
-				"reactiveSurface": 3,
-				"maxNestingDepth": 4,
-				"distinctOperators": 7,
-				"distinctOperands": 22,
-				"cssSelectorParts": 0,
-				"directives": 1,
-				"eventHandlers": 0,
-				"bindings": 1,
-				"stateAtoms": 1,
-				"vocabulary": 26
-			}
-		},
-		"vue": {
-			"bundleSize": 29.88,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/vue",
-				"inlineJsBytes": 3593,
-				"jsRequestCount": 3,
-				"jsRawBytes": 76043,
-				"jsNormalizedBytes": 30602,
-				"jsSources": [
-					{
-						"kind": "inline",
-						"rawBytes": 3593,
-						"normalizedBytes": 1473
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/VueNestedCheckboxes.CDGCsvTy.js",
-						"rawBytes": 1314,
-						"normalizedBytes": 716
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/client.Blg3hzg8.js",
-						"rawBytes": 987,
-						"normalizedBytes": 611
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/runtime-dom.esm-bundler.DNuA_tq2.js",
-						"rawBytes": 70149,
-						"normalizedBytes": 27802
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 3593,
-				"jsImplementationNormalizedBytes": 30602,
-				"jsImplementationNormalizedKiB": 29.88,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 35,
-			"codeComplexity": 69,
-			"vibeComplexity": 18,
-			"bundleSizeZScore": 0.6031480051610527,
-			"codeComplexityZScore": 0.868432451122405,
-			"vibeComplexityZScore": -1.0462508403727167,
-			"codeComplexitySubscores": {
-				"size": 19,
-				"logic": 7.9,
-				"reactive": 10.3,
-				"nesting": 18,
-				"vocabulary": 13.8
-			},
-			"codeComplexityRaw": {
-				"astNodes": 191,
-				"logicDecisions": 2,
-				"reactiveSurface": 5,
-				"maxNestingDepth": 4,
-				"distinctOperators": 21,
-				"distinctOperands": 41,
-				"cssSelectorParts": 0,
-				"directives": 1,
-				"eventHandlers": 0,
-				"bindings": 1,
-				"stateAtoms": 3,
-				"vocabulary": 46
-			}
-		},
-		"react": {
-			"bundleSize": 60.34,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/react",
-				"inlineJsBytes": 3593,
-				"jsRequestCount": 4,
-				"jsRawBytes": 191048,
-				"jsNormalizedBytes": 61785,
-				"jsSources": [
-					{
-						"kind": "inline",
-						"rawBytes": 3593,
-						"normalizedBytes": 1473
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/ReactNestedCheckboxes.DeXrk-E4.js",
-						"rawBytes": 1036,
-						"normalizedBytes": 512
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/client.BA2GgrTr.js",
-						"rawBytes": 177920,
-						"normalizedBytes": 56338
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/jsx-runtime.D_zvdyIk.js",
-						"rawBytes": 725,
-						"normalizedBytes": 460
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/index.Dy6lLLXr.js",
-						"rawBytes": 7774,
-						"normalizedBytes": 3002
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 3593,
-				"jsImplementationNormalizedBytes": 61785,
-				"jsImplementationNormalizedKiB": 60.34,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 72,
-			"codeComplexity": 72,
-			"vibeComplexity": 68,
-			"bundleSizeZScore": 2.3920368305949067,
-			"codeComplexityZScore": 1.046877475325639,
-			"vibeComplexityZScore": 1.1334384104037762,
-			"codeComplexitySubscores": {
-				"size": 20,
-				"logic": 10,
-				"reactive": 14.8,
-				"nesting": 12,
-				"vocabulary": 15.3
-			},
-			"codeComplexityRaw": {
-				"astNodes": 326,
-				"logicDecisions": 3,
-				"reactiveSurface": 12,
-				"maxNestingDepth": 3,
-				"distinctOperators": 38,
-				"distinctOperands": 47,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 3,
-				"bindings": 0,
-				"stateAtoms": 9,
-				"vocabulary": 59
-			}
-		},
-		"svelte": {
-			"bundleSize": 10.34,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/svelte",
-				"inlineJsBytes": 3593,
-				"jsRequestCount": 3,
-				"jsRawBytes": 24270,
-				"jsNormalizedBytes": 10585,
-				"jsSources": [
-					{
-						"kind": "inline",
-						"rawBytes": 3593,
-						"normalizedBytes": 1473
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/SvelteNestedCheckboxes.D5VZY1PO.js",
-						"rawBytes": 4992,
-						"normalizedBytes": 2488
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/client.svelte.Dv1zzMyf.js",
-						"rawBytes": 1093,
-						"normalizedBytes": 599
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/render.DIwoxc2i.js",
-						"rawBytes": 14592,
-						"normalizedBytes": 6025
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 3593,
-				"jsImplementationNormalizedBytes": 10585,
-				"jsImplementationNormalizedKiB": 10.34,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 37,
-			"codeComplexity": 53,
-			"vibeComplexity": 15,
-			"bundleSizeZScore": -0.5444188907344657,
-			"codeComplexityZScore": -0.08327434462817572,
-			"vibeComplexityZScore": -1.1770321954193061,
-			"codeComplexitySubscores": {
-				"size": 18.3,
-				"logic": 10,
-				"reactive": 8,
-				"nesting": 3,
-				"vocabulary": 13.8
-			},
-			"codeComplexityRaw": {
-				"astNodes": 174,
-				"logicDecisions": 3,
-				"reactiveSurface": 3,
-				"maxNestingDepth": 1,
-				"distinctOperators": 24,
-				"distinctOperands": 37,
-				"cssSelectorParts": 0,
-				"directives": 1,
-				"eventHandlers": 0,
-				"bindings": 2,
-				"stateAtoms": 0,
-				"vocabulary": 46
-			}
-		},
-		"hyperscript": {
-			"bundleSize": 24.94,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/hyperscript",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 2,
-				"jsRawBytes": 100869,
-				"jsNormalizedBytes": 25542,
-				"jsSources": [
-					{
-						"kind": "first-party",
-						"url": "/_astro/hyperscript.astro_astro_type_script_index_0_lang.D8yl2yzw.js",
-						"rawBytes": 50,
-						"normalizedBytes": 70
-					},
-					{
-						"kind": "external",
-						"url": "https://unpkg.com/hyperscript.org@0.9.13",
-						"rawBytes": 100819,
-						"normalizedBytes": 25472
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 25542,
-				"jsImplementationNormalizedKiB": 24.94,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 23,
-			"codeComplexity": 24,
-			"vibeComplexity": 48,
-			"bundleSizeZScore": 0.31302617989371095,
-			"codeComplexityZScore": -1.8082429119261032,
-			"vibeComplexityZScore": 0.26156271009317916,
-			"codeComplexitySubscores": {
-				"size": 12.5,
-				"logic": 0,
-				"reactive": 4,
-				"nesting": 0,
-				"vocabulary": 7.9
-			},
-			"codeComplexityRaw": {
-				"astNodes": 78,
-				"logicDecisions": 0,
-				"reactiveSurface": 1,
-				"maxNestingDepth": 0,
-				"distinctOperators": 7,
-				"distinctOperands": 11,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 1,
-				"bindings": 0,
-				"stateAtoms": 0,
-				"vocabulary": 16
-			}
-		},
-		"cssOnly": {
-			"bundleSize": 0,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/cssOnly",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 0,
-				"jsRawBytes": 0,
-				"jsNormalizedBytes": 0,
-				"jsSources": [],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 0,
-				"jsImplementationNormalizedKiB": 0,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 80,
-			"codeComplexity": 86,
-			"vibeComplexity": 92,
-			"bundleSizeZScore": -1.1516779339053798,
-			"codeComplexityZScore": 1.879620921607397,
-			"vibeComplexityZScore": 2.1796892507764927,
-			"codeComplexitySubscores": {
-				"size": 20,
-				"logic": 20,
-				"reactive": 11.2,
-				"nesting": 20,
-				"vocabulary": 14.5
-			},
-			"codeComplexityRaw": {
-				"astNodes": 291,
-				"logicDecisions": 27,
-				"reactiveSurface": 6,
-				"maxNestingDepth": 6,
-				"distinctOperators": 26,
-				"distinctOperands": 46,
-				"cssSelectorParts": 415,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 6,
-				"stateAtoms": 0,
-				"vocabulary": 52
-			}
-		},
-		"jquery": {
-			"bundleSize": 30.84,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/jquery",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 1,
-				"jsRawBytes": 88096,
-				"jsNormalizedBytes": 31576,
-				"jsSources": [
-					{
-						"kind": "first-party",
-						"url": "/_astro/jquery.astro_astro_type_script_index_0_lang.Bc3_QL3Q.js",
-						"rawBytes": 88096,
-						"normalizedBytes": 31576
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 31576,
-				"jsImplementationNormalizedKiB": 30.84,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 34,
-			"codeComplexity": 43,
-			"vibeComplexity": 35,
-			"bundleSizeZScore": 0.6595279550105767,
-			"codeComplexityZScore": -0.6780910919722887,
-			"vibeComplexityZScore": -0.305156495108709,
-			"codeComplexitySubscores": {
-				"size": 18.4,
-				"logic": 5,
-				"reactive": 0,
-				"nesting": 7,
-				"vocabulary": 12.1
-			},
-			"codeComplexityRaw": {
-				"astNodes": 176,
-				"logicDecisions": 1,
-				"reactiveSurface": 0,
-				"maxNestingDepth": 2,
-				"distinctOperators": 19,
-				"distinctOperands": 28,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 0,
-				"stateAtoms": 0,
-				"vocabulary": 35
-			}
-		},
-		"stimulus": {
-			"bundleSize": 10.87,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/stimulus",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 1,
-				"jsRawBytes": 45459,
-				"jsNormalizedBytes": 11129,
-				"jsSources": [
-					{
-						"kind": "first-party",
-						"url": "/_astro/stimulus.astro_astro_type_script_index_0_lang.BQs1VWcS.js",
-						"rawBytes": 45459,
-						"normalizedBytes": 11129
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 11129,
-				"jsImplementationNormalizedKiB": 10.87,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 42,
-			"codeComplexity": 48,
-			"vibeComplexity": 52,
-			"bundleSizeZScore": -0.5132924600883744,
-			"codeComplexityZScore": -0.3806827183002322,
-			"vibeComplexityZScore": 0.43593785015529857,
-			"codeComplexitySubscores": {
-				"size": 18.8,
-				"logic": 7.9,
-				"reactive": 0,
-				"nesting": 7,
-				"vocabulary": 14.7
-			},
-			"codeComplexityRaw": {
-				"astNodes": 187,
-				"logicDecisions": 2,
-				"reactiveSurface": 0,
-				"maxNestingDepth": 2,
-				"distinctOperators": 23,
-				"distinctOperands": 46,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 0,
-				"stateAtoms": 0,
-				"vocabulary": 53
-			}
-		},
-		"datastar": {
-			"bundleSize": 12.97,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/datastar",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 1,
-				"jsRawBytes": 34137,
-				"jsNormalizedBytes": 13278,
-				"jsSources": [
-					{
-						"kind": "external",
-						"url": "https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.1/bundles/datastar.js",
-						"rawBytes": 34137,
-						"normalizedBytes": 13278
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 13278,
-				"jsImplementationNormalizedKiB": 12.97,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 28,
-			"codeComplexity": 40,
-			"vibeComplexity": 42,
-			"bundleSizeZScore": -0.38996131979254073,
-			"codeComplexityZScore": -0.8565361161755225,
-			"vibeComplexityZScore": 0,
-			"codeComplexitySubscores": {
-				"size": 14.9,
-				"logic": 0,
-				"reactive": 14.3,
-				"nesting": 0,
-				"vocabulary": 11
-			},
-			"codeComplexityRaw": {
-				"astNodes": 110,
-				"logicDecisions": 0,
-				"reactiveSurface": 11,
-				"maxNestingDepth": 0,
-				"distinctOperators": 7,
-				"distinctOperands": 24,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 6,
-				"stateAtoms": 5,
-				"vocabulary": 29
-			}
-		}
-	}
+  "metadata": {
+    "lastUpdated": "2026-06-10T18:09:39.049Z",
+    "description": "Framework comparison metrics",
+    "codeComplexityVersion": "cc-1.0.0",
+    "bundleMeasurementVersion": "bm-2.0.0",
+    "metrics": {
+      "bundleSize": "Normalized implementation JavaScript payload (KiB): built chunks, external runtimes, and inline JS above baseline",
+      "sourceLines": "Line count of the implementation source file shown on each card",
+      "codeComplexity": "Deterministic 0-100 composite of size, logic, reactive, nesting, and vocabulary",
+      "vibeComplexity": "AI-judged implementation complexity on a 0-100 scale",
+      "bundleSizeZScore": "Standardized score relative to mean",
+      "codeComplexityZScore": "Standardized score relative to mean",
+      "vibeComplexityZScore": "Standardized score relative to mean"
+    }
+  },
+  "frameworks": {
+    "vanillajs": {
+      "bundleSize": 0.28,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/vanillajs",
+        "inlineJsBytes": 610,
+        "jsRequestCount": 0,
+        "jsRawBytes": 610,
+        "jsNormalizedBytes": 287,
+        "jsSources": [
+          {
+            "kind": "inline",
+            "rawBytes": 610,
+            "normalizedBytes": 287
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 610,
+        "jsImplementationNormalizedBytes": 287,
+        "jsImplementationNormalizedKiB": 0.28,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 28,
+      "codeComplexity": 54,
+      "vibeComplexity": 28,
+      "bundleSizeZScore": -1.1374307204196847,
+      "codeComplexityZScore": 0,
+      "vibeComplexityZScore": -0.610312990217418,
+      "codeComplexitySubscores": {
+        "size": 18,
+        "logic": 11.6,
+        "reactive": 0,
+        "nesting": 12,
+        "vocabulary": 12
+      },
+      "codeComplexityRaw": {
+        "astNodes": 167,
+        "logicDecisions": 4,
+        "reactiveSurface": 0,
+        "maxNestingDepth": 3,
+        "distinctOperators": 21,
+        "distinctOperands": 27,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 0,
+        "stateAtoms": 0,
+        "vocabulary": 34
+      }
+    },
+    "alpine": {
+      "bundleSize": 15.64,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/alpine",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 1,
+        "jsRawBytes": 44258,
+        "jsNormalizedBytes": 16019,
+        "jsSources": [
+          {
+            "kind": "first-party",
+            "url": "/_astro/alpine.astro_astro_type_script_index_0_lang.DtrxmssH.js",
+            "rawBytes": 44258,
+            "normalizedBytes": 16019
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 16019,
+        "jsImplementationNormalizedKiB": 15.64,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 33,
+      "codeComplexity": 55,
+      "vibeComplexity": 22,
+      "bundleSizeZScore": -0.23672773203764844,
+      "codeComplexityZScore": 0.058163132071278635,
+      "vibeComplexityZScore": -0.8718757003105971,
+      "codeComplexitySubscores": {
+        "size": 13.6,
+        "logic": 5,
+        "reactive": 8,
+        "nesting": 18,
+        "vocabulary": 10.4
+      },
+      "codeComplexityRaw": {
+        "astNodes": 92,
+        "logicDecisions": 1,
+        "reactiveSurface": 3,
+        "maxNestingDepth": 4,
+        "distinctOperators": 7,
+        "distinctOperands": 22,
+        "cssSelectorParts": 0,
+        "directives": 1,
+        "eventHandlers": 0,
+        "bindings": 1,
+        "stateAtoms": 1,
+        "vocabulary": 26
+      }
+    },
+    "vue": {
+      "bundleSize": 29.96,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/vue",
+        "inlineJsBytes": 3593,
+        "jsRequestCount": 3,
+        "jsRawBytes": 76165,
+        "jsNormalizedBytes": 30675,
+        "jsSources": [
+          {
+            "kind": "inline",
+            "rawBytes": 3593,
+            "normalizedBytes": 1473
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/VueNestedCheckboxes.COcBbwXs.js",
+            "rawBytes": 1314,
+            "normalizedBytes": 716
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/client.D5L2eC4z.js",
+            "rawBytes": 1006,
+            "normalizedBytes": 622
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/runtime-dom.esm-bundler.3XiaR-zg.js",
+            "rawBytes": 70252,
+            "normalizedBytes": 27864
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 3593,
+        "jsImplementationNormalizedBytes": 30675,
+        "jsImplementationNormalizedKiB": 29.96,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 35,
+      "codeComplexity": 69,
+      "vibeComplexity": 18,
+      "bundleSizeZScore": 0.6029901581726875,
+      "codeComplexityZScore": 0.8724469810691796,
+      "vibeComplexityZScore": -1.0462508403727167,
+      "codeComplexitySubscores": {
+        "size": 19,
+        "logic": 7.9,
+        "reactive": 10.3,
+        "nesting": 18,
+        "vocabulary": 13.8
+      },
+      "codeComplexityRaw": {
+        "astNodes": 191,
+        "logicDecisions": 2,
+        "reactiveSurface": 5,
+        "maxNestingDepth": 4,
+        "distinctOperators": 21,
+        "distinctOperands": 41,
+        "cssSelectorParts": 0,
+        "directives": 1,
+        "eventHandlers": 0,
+        "bindings": 1,
+        "stateAtoms": 3,
+        "vocabulary": 46
+      }
+    },
+    "react": {
+      "bundleSize": 60.52,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/react",
+        "inlineJsBytes": 3593,
+        "jsRequestCount": 4,
+        "jsRawBytes": 192651,
+        "jsNormalizedBytes": 61973,
+        "jsSources": [
+          {
+            "kind": "inline",
+            "rawBytes": 3593,
+            "normalizedBytes": 1473
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/ReactNestedCheckboxes.hD1sQuFN.js",
+            "rawBytes": 1036,
+            "normalizedBytes": 512
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/client.BPIbHqJh.js",
+            "rawBytes": 179414,
+            "normalizedBytes": 56476
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/jsx-runtime.D_zvdyIk.js",
+            "rawBytes": 725,
+            "normalizedBytes": 460
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/index.BVOCwoKb.js",
+            "rawBytes": 7883,
+            "normalizedBytes": 3052
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 3593,
+        "jsImplementationNormalizedBytes": 61973,
+        "jsImplementationNormalizedKiB": 60.52,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 72,
+      "codeComplexity": 72,
+      "vibeComplexity": 68,
+      "bundleSizeZScore": 2.395013812141114,
+      "codeComplexityZScore": 1.0469363772830156,
+      "vibeComplexityZScore": 1.1334384104037762,
+      "codeComplexitySubscores": {
+        "size": 20,
+        "logic": 10,
+        "reactive": 14.8,
+        "nesting": 12,
+        "vocabulary": 15.3
+      },
+      "codeComplexityRaw": {
+        "astNodes": 326,
+        "logicDecisions": 3,
+        "reactiveSurface": 12,
+        "maxNestingDepth": 3,
+        "distinctOperators": 38,
+        "distinctOperands": 47,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 3,
+        "bindings": 0,
+        "stateAtoms": 9,
+        "vocabulary": 59
+      }
+    },
+    "svelte": {
+      "bundleSize": 10.75,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/svelte",
+        "inlineJsBytes": 3593,
+        "jsRequestCount": 3,
+        "jsRawBytes": 25191,
+        "jsNormalizedBytes": 11008,
+        "jsSources": [
+          {
+            "kind": "inline",
+            "rawBytes": 3593,
+            "normalizedBytes": 1473
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/SvelteNestedCheckboxes.DxZtJmGM.js",
+            "rawBytes": 5099,
+            "normalizedBytes": 2544
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/client.svelte.DWhurY4S.js",
+            "rawBytes": 1125,
+            "normalizedBytes": 622
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/render.C9LCoNJT.js",
+            "rawBytes": 15374,
+            "normalizedBytes": 6369
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 3593,
+        "jsImplementationNormalizedBytes": 11008,
+        "jsImplementationNormalizedKiB": 10.75,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 37,
+      "codeComplexity": 53,
+      "vibeComplexity": 15,
+      "bundleSizeZScore": -0.5234749724795859,
+      "codeComplexityZScore": -0.058163132071278635,
+      "vibeComplexityZScore": -1.1770321954193061,
+      "codeComplexitySubscores": {
+        "size": 18.3,
+        "logic": 10,
+        "reactive": 8,
+        "nesting": 3,
+        "vocabulary": 13.8
+      },
+      "codeComplexityRaw": {
+        "astNodes": 174,
+        "logicDecisions": 3,
+        "reactiveSurface": 3,
+        "maxNestingDepth": 1,
+        "distinctOperators": 24,
+        "distinctOperands": 37,
+        "cssSelectorParts": 0,
+        "directives": 1,
+        "eventHandlers": 0,
+        "bindings": 2,
+        "stateAtoms": 0,
+        "vocabulary": 46
+      }
+    },
+    "hyperscript": {
+      "bundleSize": 24.94,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/hyperscript",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 2,
+        "jsRawBytes": 100869,
+        "jsNormalizedBytes": 25542,
+        "jsSources": [
+          {
+            "kind": "first-party",
+            "url": "/_astro/hyperscript.astro_astro_type_script_index_0_lang.D8yl2yzw.js",
+            "rawBytes": 50,
+            "normalizedBytes": 70
+          },
+          {
+            "kind": "external",
+            "url": "https://unpkg.com/hyperscript.org@0.9.13",
+            "rawBytes": 100819,
+            "normalizedBytes": 25472
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 25542,
+        "jsImplementationNormalizedKiB": 24.94,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 23,
+      "codeComplexity": 24,
+      "vibeComplexity": 48,
+      "bundleSizeZScore": 0.3086197804592877,
+      "codeComplexityZScore": -1.7448939621383592,
+      "vibeComplexityZScore": 0.26156271009317916,
+      "codeComplexitySubscores": {
+        "size": 12.5,
+        "logic": 0,
+        "reactive": 4,
+        "nesting": 0,
+        "vocabulary": 7.9
+      },
+      "codeComplexityRaw": {
+        "astNodes": 78,
+        "logicDecisions": 0,
+        "reactiveSurface": 1,
+        "maxNestingDepth": 0,
+        "distinctOperators": 7,
+        "distinctOperands": 11,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 1,
+        "bindings": 0,
+        "stateAtoms": 0,
+        "vocabulary": 16
+      }
+    },
+    "cssOnly": {
+      "bundleSize": 0,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/cssOnly",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 0,
+        "jsRawBytes": 0,
+        "jsNormalizedBytes": 0,
+        "jsSources": [],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 0,
+        "jsImplementationNormalizedKiB": 0,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 80,
+      "codeComplexity": 86,
+      "vibeComplexity": 92,
+      "bundleSizeZScore": -1.1538497853120657,
+      "codeComplexityZScore": 1.8612202262809163,
+      "vibeComplexityZScore": 2.1796892507764927,
+      "codeComplexitySubscores": {
+        "size": 20,
+        "logic": 20,
+        "reactive": 11.2,
+        "nesting": 20,
+        "vocabulary": 14.5
+      },
+      "codeComplexityRaw": {
+        "astNodes": 291,
+        "logicDecisions": 27,
+        "reactiveSurface": 6,
+        "maxNestingDepth": 6,
+        "distinctOperators": 26,
+        "distinctOperands": 46,
+        "cssSelectorParts": 415,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 6,
+        "stateAtoms": 0,
+        "vocabulary": 52
+      }
+    },
+    "jquery": {
+      "bundleSize": 30.84,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/jquery",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 1,
+        "jsRawBytes": 88096,
+        "jsNormalizedBytes": 31576,
+        "jsSources": [
+          {
+            "kind": "first-party",
+            "url": "/_astro/jquery.astro_astro_type_script_index_0_lang.Bc3_QL3Q.js",
+            "rawBytes": 88096,
+            "normalizedBytes": 31576
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 31576,
+        "jsImplementationNormalizedKiB": 30.84,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 34,
+      "codeComplexity": 43,
+      "vibeComplexity": 35,
+      "bundleSizeZScore": 0.6545929335487417,
+      "codeComplexityZScore": -0.639794452784065,
+      "vibeComplexityZScore": -0.305156495108709,
+      "codeComplexitySubscores": {
+        "size": 18.4,
+        "logic": 5,
+        "reactive": 0,
+        "nesting": 7,
+        "vocabulary": 12.1
+      },
+      "codeComplexityRaw": {
+        "astNodes": 176,
+        "logicDecisions": 1,
+        "reactiveSurface": 0,
+        "maxNestingDepth": 2,
+        "distinctOperators": 19,
+        "distinctOperands": 28,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 0,
+        "stateAtoms": 0,
+        "vocabulary": 35
+      }
+    },
+    "stimulus": {
+      "bundleSize": 10.87,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/stimulus",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 1,
+        "jsRawBytes": 45459,
+        "jsNormalizedBytes": 11129,
+        "jsSources": [
+          {
+            "kind": "first-party",
+            "url": "/_astro/stimulus.astro_astro_type_script_index_0_lang.BQs1VWcS.js",
+            "rawBytes": 45459,
+            "normalizedBytes": 11129
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 11129,
+        "jsImplementationNormalizedKiB": 10.87,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 42,
+      "codeComplexity": 48,
+      "vibeComplexity": 52,
+      "bundleSizeZScore": -0.5164382303828512,
+      "codeComplexityZScore": -0.3489787924276718,
+      "vibeComplexityZScore": 0.43593785015529857,
+      "codeComplexitySubscores": {
+        "size": 18.8,
+        "logic": 7.9,
+        "reactive": 0,
+        "nesting": 7,
+        "vocabulary": 14.7
+      },
+      "codeComplexityRaw": {
+        "astNodes": 187,
+        "logicDecisions": 2,
+        "reactiveSurface": 0,
+        "maxNestingDepth": 2,
+        "distinctOperators": 23,
+        "distinctOperands": 46,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 0,
+        "stateAtoms": 0,
+        "vocabulary": 53
+      }
+    },
+    "datastar": {
+      "bundleSize": 12.97,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/datastar",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 1,
+        "jsRawBytes": 34137,
+        "jsNormalizedBytes": 13278,
+        "jsSources": [
+          {
+            "kind": "external",
+            "url": "https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.1/bundles/datastar.js",
+            "rawBytes": 34137,
+            "normalizedBytes": 13278
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 13278,
+        "jsImplementationNormalizedKiB": 12.97,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "sourceLines": 26,
+      "codeComplexity": 36,
+      "vibeComplexity": 42,
+      "bundleSizeZScore": -0.3932952436899946,
+      "codeComplexityZScore": -1.0469363772830156,
+      "vibeComplexityZScore": 0,
+      "codeComplexitySubscores": {
+        "size": 14.1,
+        "logic": 0,
+        "reactive": 12,
+        "nesting": 0,
+        "vocabulary": 10
+      },
+      "codeComplexityRaw": {
+        "astNodes": 98,
+        "logicDecisions": 0,
+        "reactiveSurface": 7,
+        "maxNestingDepth": 0,
+        "distinctOperators": 7,
+        "distinctOperands": 19,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 5,
+        "stateAtoms": 2,
+        "vocabulary": 24
+      }
+    }
+  }
 }


### PR DESCRIPTION
Refactored the Datastar checkbox implementation to use a collection of child checkbox states instead of assuming a fixed number of child checkboxes.

Related to #101