### PR TITLE
Add bundle composition breakdown (runtime vs. per-component)

### DIFF
--- a/src/components/shared/BundleCompositionChart.astro
+++ b/src/components/shared/BundleCompositionChart.astro
@@ -1,0 +1,206 @@
+---
+/**
+ * BundleCompositionChart.astro
+ *
+ * Renders the measured runtime-vs-per-component bundle split that
+ * `generate-stats` computes and stores in framework-stats.json
+ * (bundleRuntimeKiB / bundleComponentKiB / bundleSplittable). No classification
+ * happens here — this component just displays the stored numbers, so the values
+ * recompute on every `pnpm generate-stats`.
+ */
+
+import stats from "../../data/framework-stats.json";
+
+const LABELS: Record<string, string> = {
+	react: "React",
+	vue: "Vue",
+	svelte: "Svelte",
+	alpine: "Alpine.js",
+	vanillajs: "Vanilla JS",
+	jquery: "jQuery",
+	stimulus: "Stimulus",
+	datastar: "Datastar",
+	hyperscript: "Hyperscript",
+	cssOnly: "CSS Only",
+};
+
+interface FrameworkStat {
+	bundleRuntimeKiB: number;
+	bundleComponentKiB: number;
+	bundleSplittable: boolean;
+}
+
+const rows = Object.entries(stats.frameworks as Record<string, FrameworkStat>)
+	.map(([id, f]) => ({
+		id,
+		label: LABELS[id] ?? id,
+		runtimeKiB: f.bundleRuntimeKiB ?? 0,
+		componentKiB: f.bundleComponentKiB ?? 0,
+		totalKiB: Number(((f.bundleRuntimeKiB ?? 0) + (f.bundleComponentKiB ?? 0)).toFixed(2)),
+		bundled: f.bundleSplittable === false,
+	}))
+	.sort((a, b) => b.totalKiB - a.totalKiB);
+
+const maxTotal = Math.max(...rows.map((r) => r.totalKiB), 1);
+const pct = (v: number) => `${(v / maxTotal) * 100}%`;
+const hasBundled = rows.some((r) => r.bundled);
+---
+
+<div
+	class="bundle-comp backdrop-blur-sm bg-white/90 rounded-xl shadow-lg border border-slate-200 overflow-hidden"
+>
+	<div class="bg-white/60 px-4 py-3 border-b border-white/20 backdrop-blur-md">
+		<h3 class="font-semibold text-gray-700 select-none">
+			Where the bundle goes: runtime vs. per-component
+		</h3>
+		<p class="text-xs text-slate-500 mt-0.5">
+			Measured JS (KiB, gzip) split into framework runtime paid once and the JS
+			this one component adds. For a widget this small the per-component JS is
+			&le;4 KiB everywhere &mdash; the bundle is almost entirely fixed runtime.
+		</p>
+	</div>
+
+	<div class="bundle-comp-body">
+		<div class="bundle-legend">
+			<span class="bundle-legend-item"
+				><span class="sw sw-runtime"></span>shared runtime (paid once)</span
+			>
+			<span class="bundle-legend-item"
+				><span class="sw sw-component"></span>per-component JS (this widget)</span
+			>
+		</div>
+
+		<div class="bundle-rows">
+			{
+				rows.map((r) => (
+					<div class="bundle-row">
+						<div class="bundle-label">{r.label}</div>
+						<div class="bundle-track">
+							{r.runtimeKiB > 0 && (
+								<div
+									class="seg seg-runtime"
+									style={`width:${pct(r.runtimeKiB)}`}
+									title={`${r.label} runtime: ${r.runtimeKiB} KiB`}
+								/>
+							)}
+							{r.componentKiB > 0 && (
+								<div
+									class="seg seg-component"
+									style={`width:${pct(r.componentKiB)}; min-width:3px`}
+									title={`${r.label} per-component: ${r.componentKiB} KiB`}
+								/>
+							)}
+						</div>
+						<div class="bundle-value">
+							{r.totalKiB} KiB{r.bundled ? <span class="bundle-flag">*</span> : null}
+						</div>
+					</div>
+				))
+			}
+		</div>
+
+		<p class="bundle-footnote">
+			Measures JavaScript only. Datastar, Alpine, and Hyperscript express
+			per-component behavior as HTML attributes, so their per-component cost
+			reads as ~0 here &mdash; it isn't free, it moves into markup this view
+			doesn't count.
+			{
+				hasBundled && (
+					<Fragment>
+						{" "}
+						<span class="bundle-flag">*</span> jQuery, Alpine, and Stimulus bundle
+						their library into one chunk with the implementation, so per-component
+						JS can't be separated from runtime &mdash; shown entirely as runtime.
+					</Fragment>
+				)
+			}
+		</p>
+	</div>
+</div>
+
+<style>
+	.bundle-comp-body {
+		padding: 0.85rem 1rem 1.1rem;
+	}
+
+	.bundle-legend {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem 1rem;
+		margin-bottom: 0.9rem;
+		font-size: 0.72rem;
+		color: rgb(71 85 105);
+	}
+
+	.bundle-legend-item {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+	}
+
+	.sw {
+		display: inline-block;
+		width: 12px;
+		height: 12px;
+		border-radius: 3px;
+	}
+
+	.sw-runtime {
+		background: #64748b;
+	}
+
+	.sw-component {
+		background: #f59e0b;
+	}
+
+	.bundle-row {
+		display: grid;
+		grid-template-columns: 5.5rem 1fr 5rem;
+		align-items: center;
+		gap: 0.6rem;
+		padding: 0.22rem 0;
+	}
+
+	.bundle-label {
+		font-size: 0.8rem;
+		color: rgb(55 65 81);
+		text-align: right;
+	}
+
+	.bundle-track {
+		display: flex;
+		height: 14px;
+		background: rgb(241 245 249);
+		border-radius: 4px;
+		overflow: hidden;
+	}
+
+	.seg {
+		height: 100%;
+	}
+
+	.seg-runtime {
+		background: #64748b;
+	}
+
+	.seg-component {
+		background: #f59e0b;
+	}
+
+	.bundle-value {
+		font-size: 0.75rem;
+		color: rgb(71 85 105);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.bundle-flag {
+		color: rgb(148 163 184);
+	}
+
+	.bundle-footnote {
+		margin-top: 0.85rem;
+		font-size: 0.68rem;
+		line-height: 1.4;
+		color: rgb(148 163 184);
+	}
+</style>

--- a/src/data/framework-stats.json
+++ b/src/data/framework-stats.json
@@ -1,599 +1,629 @@
 {
-	"metadata": {
-		"lastUpdated": "2026-06-19T19:07:33.022Z",
-		"description": "Framework comparison metrics",
-		"codeComplexityVersion": "cc-1.0.0",
-		"bundleMeasurementVersion": "bm-2.0.0",
-		"metrics": {
-			"bundleSize": "Normalized implementation JavaScript payload (KiB): built chunks, external runtimes, and inline JS above baseline",
-			"sourceLines": "Line count of the implementation source file shown on each card",
-			"codeComplexity": "Deterministic 0-100 composite of size, logic, reactive, nesting, and vocabulary",
-			"vibeComplexity": "AI-judged implementation complexity on a 0-100 scale",
-			"bundleSizeZScore": "Standardized score relative to mean",
-			"codeComplexityZScore": "Standardized score relative to mean",
-			"vibeComplexityZScore": "Standardized score relative to mean"
-		}
-	},
-	"frameworks": {
-		"vanillajs": {
-			"bundleSize": 0.28,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/vanillajs",
-				"inlineJsBytes": 610,
-				"jsRequestCount": 0,
-				"jsRawBytes": 610,
-				"jsNormalizedBytes": 287,
-				"jsSources": [
-					{
-						"kind": "inline",
-						"rawBytes": 610,
-						"normalizedBytes": 287
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 610,
-				"jsImplementationNormalizedBytes": 287,
-				"jsImplementationNormalizedKiB": 0.28,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 28,
-			"codeComplexity": 54,
-			"vibeComplexity": 32,
-			"bundleSizeZScore": -1.1374870539068735,
-			"codeComplexityZScore": 0,
-			"vibeComplexityZScore": -0.5266316386975008,
-			"codeComplexitySubscores": {
-				"size": 18,
-				"logic": 11.6,
-				"reactive": 0,
-				"nesting": 12,
-				"vocabulary": 12
-			},
-			"codeComplexityRaw": {
-				"astNodes": 167,
-				"logicDecisions": 4,
-				"reactiveSurface": 0,
-				"maxNestingDepth": 3,
-				"distinctOperators": 21,
-				"distinctOperands": 27,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 0,
-				"stateAtoms": 0,
-				"vocabulary": 34
-			}
-		},
-		"alpine": {
-			"bundleSize": 15.64,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/alpine",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 1,
-				"jsRawBytes": 44252,
-				"jsNormalizedBytes": 16016,
-				"jsSources": [
-					{
-						"kind": "first-party",
-						"url": "/_astro/alpine.astro_astro_type_script_index_0_lang.CsTWmXi2.js",
-						"rawBytes": 44252,
-						"normalizedBytes": 16016
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 16016,
-				"jsImplementationNormalizedKiB": 15.64,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 33,
-			"codeComplexity": 55,
-			"vibeComplexity": 28,
-			"bundleSizeZScore": -0.23766724919916493,
-			"codeComplexityZScore": 0.058163132071278635,
-			"vibeComplexityZScore": -0.7098078608531533,
-			"codeComplexitySubscores": {
-				"size": 13.6,
-				"logic": 5,
-				"reactive": 8,
-				"nesting": 18,
-				"vocabulary": 10.4
-			},
-			"codeComplexityRaw": {
-				"astNodes": 92,
-				"logicDecisions": 1,
-				"reactiveSurface": 3,
-				"maxNestingDepth": 4,
-				"distinctOperators": 7,
-				"distinctOperands": 22,
-				"cssSelectorParts": 0,
-				"directives": 1,
-				"eventHandlers": 0,
-				"bindings": 1,
-				"stateAtoms": 1,
-				"vocabulary": 26
-			}
-		},
-		"vue": {
-			"bundleSize": 30.02,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/vue",
-				"inlineJsBytes": 3592,
-				"jsRequestCount": 3,
-				"jsRawBytes": 76164,
-				"jsNormalizedBytes": 30744,
-				"jsSources": [
-					{
-						"kind": "inline",
-						"rawBytes": 130,
-						"normalizedBytes": 125
-					},
-					{
-						"kind": "inline",
-						"rawBytes": 3462,
-						"normalizedBytes": 1417
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/VueNestedCheckboxes.COcBbwXs.js",
-						"rawBytes": 1314,
-						"normalizedBytes": 716
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/client.D5L2eC4z.js",
-						"rawBytes": 1006,
-						"normalizedBytes": 622
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/runtime-dom.esm-bundler.3XiaR-zg.js",
-						"rawBytes": 70252,
-						"normalizedBytes": 27864
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 3592,
-				"jsImplementationNormalizedBytes": 30744,
-				"jsImplementationNormalizedKiB": 30.02,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 35,
-			"codeComplexity": 69,
-			"vibeComplexity": 20,
-			"bundleSizeZScore": 0.6047421773435988,
-			"codeComplexityZScore": 0.8724469810691796,
-			"vibeComplexityZScore": -1.0761603051644582,
-			"codeComplexitySubscores": {
-				"size": 19,
-				"logic": 7.9,
-				"reactive": 10.3,
-				"nesting": 18,
-				"vocabulary": 13.8
-			},
-			"codeComplexityRaw": {
-				"astNodes": 191,
-				"logicDecisions": 2,
-				"reactiveSurface": 5,
-				"maxNestingDepth": 4,
-				"distinctOperators": 21,
-				"distinctOperands": 41,
-				"cssSelectorParts": 0,
-				"directives": 1,
-				"eventHandlers": 0,
-				"bindings": 1,
-				"stateAtoms": 3,
-				"vocabulary": 46
-			}
-		},
-		"react": {
-			"bundleSize": 60.59,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/react",
-				"inlineJsBytes": 3592,
-				"jsRequestCount": 4,
-				"jsRawBytes": 192650,
-				"jsNormalizedBytes": 62042,
-				"jsSources": [
-					{
-						"kind": "inline",
-						"rawBytes": 130,
-						"normalizedBytes": 125
-					},
-					{
-						"kind": "inline",
-						"rawBytes": 3462,
-						"normalizedBytes": 1417
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/ReactNestedCheckboxes.hD1sQuFN.js",
-						"rawBytes": 1036,
-						"normalizedBytes": 512
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/client.BPIbHqJh.js",
-						"rawBytes": 179414,
-						"normalizedBytes": 56476
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/jsx-runtime.D_zvdyIk.js",
-						"rawBytes": 725,
-						"normalizedBytes": 460
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/index.BVOCwoKb.js",
-						"rawBytes": 7883,
-						"normalizedBytes": 3052
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 3592,
-				"jsImplementationNormalizedBytes": 62042,
-				"jsImplementationNormalizedKiB": 60.59,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 72,
-			"codeComplexity": 72,
-			"vibeComplexity": 70,
-			"bundleSizeZScore": 2.395594483978668,
-			"codeComplexityZScore": 1.0469363772830156,
-			"vibeComplexityZScore": 1.2135424717811976,
-			"codeComplexitySubscores": {
-				"size": 20,
-				"logic": 10,
-				"reactive": 14.8,
-				"nesting": 12,
-				"vocabulary": 15.3
-			},
-			"codeComplexityRaw": {
-				"astNodes": 326,
-				"logicDecisions": 3,
-				"reactiveSurface": 12,
-				"maxNestingDepth": 3,
-				"distinctOperators": 38,
-				"distinctOperands": 47,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 3,
-				"bindings": 0,
-				"stateAtoms": 9,
-				"vocabulary": 59
-			}
-		},
-		"svelte": {
-			"bundleSize": 10.82,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/svelte",
-				"inlineJsBytes": 3592,
-				"jsRequestCount": 3,
-				"jsRawBytes": 25195,
-				"jsNormalizedBytes": 11080,
-				"jsSources": [
-					{
-						"kind": "inline",
-						"rawBytes": 130,
-						"normalizedBytes": 125
-					},
-					{
-						"kind": "inline",
-						"rawBytes": 3462,
-						"normalizedBytes": 1417
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/SvelteNestedCheckboxes.DVYpRgRu.js",
-						"rawBytes": 5104,
-						"normalizedBytes": 2547
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/client.svelte.CcUYxmN2.js",
-						"rawBytes": 1125,
-						"normalizedBytes": 621
-					},
-					{
-						"kind": "first-party",
-						"url": "/_astro/render.ClKQ-mU-.js",
-						"rawBytes": 15374,
-						"normalizedBytes": 6370
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 3592,
-				"jsImplementationNormalizedBytes": 11080,
-				"jsImplementationNormalizedKiB": 10.82,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 37,
-			"codeComplexity": 53,
-			"vibeComplexity": 15,
-			"bundleSizeZScore": -0.5200325785410371,
-			"codeComplexityZScore": -0.058163132071278635,
-			"vibeComplexityZScore": -1.3051305828590238,
-			"codeComplexitySubscores": {
-				"size": 18.3,
-				"logic": 10,
-				"reactive": 8,
-				"nesting": 3,
-				"vocabulary": 13.8
-			},
-			"codeComplexityRaw": {
-				"astNodes": 174,
-				"logicDecisions": 3,
-				"reactiveSurface": 3,
-				"maxNestingDepth": 1,
-				"distinctOperators": 24,
-				"distinctOperands": 37,
-				"cssSelectorParts": 0,
-				"directives": 1,
-				"eventHandlers": 0,
-				"bindings": 2,
-				"stateAtoms": 0,
-				"vocabulary": 46
-			}
-		},
-		"hyperscript": {
-			"bundleSize": 24.94,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/hyperscript",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 2,
-				"jsRawBytes": 100869,
-				"jsNormalizedBytes": 25542,
-				"jsSources": [
-					{
-						"kind": "first-party",
-						"url": "/_astro/hyperscript.astro_astro_type_script_index_0_lang.D8yl2yzw.js",
-						"rawBytes": 50,
-						"normalizedBytes": 70
-					},
-					{
-						"kind": "external",
-						"url": "https://unpkg.com/hyperscript.org@0.9.13",
-						"rawBytes": 100819,
-						"normalizedBytes": 25472
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 25542,
-				"jsImplementationNormalizedKiB": 24.94,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 23,
-			"codeComplexity": 24,
-			"vibeComplexity": 48,
-			"bundleSizeZScore": 0.30714552318245564,
-			"codeComplexityZScore": -1.7448939621383592,
-			"vibeComplexityZScore": 0.206073249925109,
-			"codeComplexitySubscores": {
-				"size": 12.5,
-				"logic": 0,
-				"reactive": 4,
-				"nesting": 0,
-				"vocabulary": 7.9
-			},
-			"codeComplexityRaw": {
-				"astNodes": 78,
-				"logicDecisions": 0,
-				"reactiveSurface": 1,
-				"maxNestingDepth": 0,
-				"distinctOperators": 7,
-				"distinctOperands": 11,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 1,
-				"bindings": 0,
-				"stateAtoms": 0,
-				"vocabulary": 16
-			}
-		},
-		"cssOnly": {
-			"bundleSize": 0,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/cssOnly",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 0,
-				"jsRawBytes": 0,
-				"jsNormalizedBytes": 0,
-				"jsSources": [],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 0,
-				"jsImplementationNormalizedKiB": 0,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 80,
-			"codeComplexity": 86,
-			"vibeComplexity": 90,
-			"bundleSizeZScore": -1.153890019096858,
-			"codeComplexityZScore": 1.8612202262809163,
-			"vibeComplexityZScore": 2.12942358255946,
-			"codeComplexitySubscores": {
-				"size": 20,
-				"logic": 20,
-				"reactive": 11.2,
-				"nesting": 20,
-				"vocabulary": 14.5
-			},
-			"codeComplexityRaw": {
-				"astNodes": 291,
-				"logicDecisions": 27,
-				"reactiveSurface": 6,
-				"maxNestingDepth": 6,
-				"distinctOperators": 26,
-				"distinctOperands": 46,
-				"cssSelectorParts": 415,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 6,
-				"stateAtoms": 0,
-				"vocabulary": 52
-			}
-		},
-		"jquery": {
-			"bundleSize": 30.84,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/jquery",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 1,
-				"jsRawBytes": 88096,
-				"jsNormalizedBytes": 31576,
-				"jsSources": [
-					{
-						"kind": "first-party",
-						"url": "/_astro/jquery.astro_astro_type_script_index_0_lang.Bc3_QL3Q.js",
-						"rawBytes": 88096,
-						"normalizedBytes": 31576
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 31576,
-				"jsImplementationNormalizedKiB": 30.84,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 34,
-			"codeComplexity": 43,
-			"vibeComplexity": 35,
-			"bundleSizeZScore": 0.6527794325428385,
-			"codeComplexityZScore": -0.639794452784065,
-			"vibeComplexityZScore": -0.3892494720807615,
-			"codeComplexitySubscores": {
-				"size": 18.4,
-				"logic": 5,
-				"reactive": 0,
-				"nesting": 7,
-				"vocabulary": 12.1
-			},
-			"codeComplexityRaw": {
-				"astNodes": 176,
-				"logicDecisions": 1,
-				"reactiveSurface": 0,
-				"maxNestingDepth": 2,
-				"distinctOperators": 19,
-				"distinctOperands": 28,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 0,
-				"stateAtoms": 0,
-				"vocabulary": 35
-			}
-		},
-		"stimulus": {
-			"bundleSize": 10.87,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/stimulus",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 1,
-				"jsRawBytes": 45459,
-				"jsNormalizedBytes": 11129,
-				"jsSources": [
-					{
-						"kind": "first-party",
-						"url": "/_astro/stimulus.astro_astro_type_script_index_0_lang.BQs1VWcS.js",
-						"rawBytes": 45459,
-						"normalizedBytes": 11129
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 11129,
-				"jsImplementationNormalizedKiB": 10.87,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 42,
-			"codeComplexity": 48,
-			"vibeComplexity": 52,
-			"bundleSizeZScore": -0.5171034776142542,
-			"codeComplexityZScore": -0.3489787924276718,
-			"vibeComplexityZScore": 0.3892494720807615,
-			"codeComplexitySubscores": {
-				"size": 18.8,
-				"logic": 7.9,
-				"reactive": 0,
-				"nesting": 7,
-				"vocabulary": 14.7
-			},
-			"codeComplexityRaw": {
-				"astNodes": 187,
-				"logicDecisions": 2,
-				"reactiveSurface": 0,
-				"maxNestingDepth": 2,
-				"distinctOperators": 23,
-				"distinctOperands": 46,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 0,
-				"stateAtoms": 0,
-				"vocabulary": 53
-			}
-		},
-		"datastar": {
-			"bundleSize": 12.97,
-			"bundleMeasurement": {
-				"measuredRoute": "/test/datastar",
-				"inlineJsBytes": 0,
-				"jsRequestCount": 1,
-				"jsRawBytes": 34137,
-				"jsNormalizedBytes": 13278,
-				"jsSources": [
-					{
-						"kind": "external",
-						"url": "https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.1/bundles/datastar.js",
-						"rawBytes": 34137,
-						"normalizedBytes": 13278
-					}
-				],
-				"baselineInlineJsBytes": 0,
-				"baselineNormalizedBytes": 0,
-				"inlineJsImplementationBytes": 0,
-				"jsImplementationNormalizedBytes": 13278,
-				"jsImplementationNormalizedKiB": 12.97,
-				"compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
-			},
-			"sourceLines": 25,
-			"codeComplexity": 36,
-			"vibeComplexity": 45,
-			"bundleSizeZScore": -0.3940812386893721,
-			"codeComplexityZScore": -1.0469363772830156,
-			"vibeComplexityZScore": 0.06869108330836968,
-			"codeComplexitySubscores": {
-				"size": 14.1,
-				"logic": 0,
-				"reactive": 12,
-				"nesting": 0,
-				"vocabulary": 9.8
-			},
-			"codeComplexityRaw": {
-				"astNodes": 98,
-				"logicDecisions": 0,
-				"reactiveSurface": 7,
-				"maxNestingDepth": 0,
-				"distinctOperators": 6,
-				"distinctOperands": 19,
-				"cssSelectorParts": 0,
-				"directives": 0,
-				"eventHandlers": 0,
-				"bindings": 5,
-				"stateAtoms": 2,
-				"vocabulary": 23
-			}
-		}
-	}
+  "metadata": {
+    "lastUpdated": "2026-06-23T12:11:42.819Z",
+    "description": "Framework comparison metrics",
+    "codeComplexityVersion": "cc-1.0.0",
+    "bundleMeasurementVersion": "bm-2.0.0",
+    "metrics": {
+      "bundleSize": "Normalized implementation JavaScript payload (KiB): built chunks, external runtimes, and inline JS above baseline",
+      "sourceLines": "Line count of the implementation source file shown on each card",
+      "codeComplexity": "Deterministic 0-100 composite of size, logic, reactive, nesting, and vocabulary",
+      "vibeComplexity": "AI-judged implementation complexity on a 0-100 scale",
+      "bundleSizeZScore": "Standardized score relative to mean",
+      "codeComplexityZScore": "Standardized score relative to mean",
+      "vibeComplexityZScore": "Standardized score relative to mean"
+    }
+  },
+  "frameworks": {
+    "vanillajs": {
+      "bundleSize": 0.28,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/vanillajs",
+        "inlineJsBytes": 610,
+        "jsRequestCount": 0,
+        "jsRawBytes": 610,
+        "jsNormalizedBytes": 287,
+        "jsSources": [
+          {
+            "kind": "inline",
+            "rawBytes": 610,
+            "normalizedBytes": 287
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 610,
+        "jsImplementationNormalizedBytes": 287,
+        "jsImplementationNormalizedKiB": 0.28,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 0,
+      "bundleComponentKiB": 0.28,
+      "bundleSplittable": true,
+      "sourceLines": 28,
+      "codeComplexity": 54,
+      "vibeComplexity": 32,
+      "bundleSizeZScore": -1.1374870539068735,
+      "codeComplexityZScore": 0,
+      "vibeComplexityZScore": -0.5266316386975008,
+      "codeComplexitySubscores": {
+        "size": 18,
+        "logic": 11.6,
+        "reactive": 0,
+        "nesting": 12,
+        "vocabulary": 12
+      },
+      "codeComplexityRaw": {
+        "astNodes": 167,
+        "logicDecisions": 4,
+        "reactiveSurface": 0,
+        "maxNestingDepth": 3,
+        "distinctOperators": 21,
+        "distinctOperands": 27,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 0,
+        "stateAtoms": 0,
+        "vocabulary": 34
+      }
+    },
+    "alpine": {
+      "bundleSize": 15.64,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/alpine",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 1,
+        "jsRawBytes": 44252,
+        "jsNormalizedBytes": 16016,
+        "jsSources": [
+          {
+            "kind": "first-party",
+            "url": "/_astro/alpine.astro_astro_type_script_index_0_lang.CsTWmXi2.js",
+            "rawBytes": 44252,
+            "normalizedBytes": 16016
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 16016,
+        "jsImplementationNormalizedKiB": 15.64,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 15.64,
+      "bundleComponentKiB": 0,
+      "bundleSplittable": false,
+      "sourceLines": 33,
+      "codeComplexity": 55,
+      "vibeComplexity": 28,
+      "bundleSizeZScore": -0.23766724919916493,
+      "codeComplexityZScore": 0.058163132071278635,
+      "vibeComplexityZScore": -0.7098078608531533,
+      "codeComplexitySubscores": {
+        "size": 13.6,
+        "logic": 5,
+        "reactive": 8,
+        "nesting": 18,
+        "vocabulary": 10.4
+      },
+      "codeComplexityRaw": {
+        "astNodes": 92,
+        "logicDecisions": 1,
+        "reactiveSurface": 3,
+        "maxNestingDepth": 4,
+        "distinctOperators": 7,
+        "distinctOperands": 22,
+        "cssSelectorParts": 0,
+        "directives": 1,
+        "eventHandlers": 0,
+        "bindings": 1,
+        "stateAtoms": 1,
+        "vocabulary": 26
+      }
+    },
+    "vue": {
+      "bundleSize": 30.02,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/vue",
+        "inlineJsBytes": 3592,
+        "jsRequestCount": 3,
+        "jsRawBytes": 76164,
+        "jsNormalizedBytes": 30744,
+        "jsSources": [
+          {
+            "kind": "inline",
+            "rawBytes": 130,
+            "normalizedBytes": 125
+          },
+          {
+            "kind": "inline",
+            "rawBytes": 3462,
+            "normalizedBytes": 1417
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/VueNestedCheckboxes.COcBbwXs.js",
+            "rawBytes": 1314,
+            "normalizedBytes": 716
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/client.D5L2eC4z.js",
+            "rawBytes": 1006,
+            "normalizedBytes": 622
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/runtime-dom.esm-bundler.3XiaR-zg.js",
+            "rawBytes": 70252,
+            "normalizedBytes": 27864
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 3592,
+        "jsImplementationNormalizedBytes": 30744,
+        "jsImplementationNormalizedKiB": 30.02,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 27.82,
+      "bundleComponentKiB": 2.21,
+      "bundleSplittable": true,
+      "sourceLines": 35,
+      "codeComplexity": 69,
+      "vibeComplexity": 20,
+      "bundleSizeZScore": 0.6047421773435988,
+      "codeComplexityZScore": 0.8724469810691796,
+      "vibeComplexityZScore": -1.0761603051644582,
+      "codeComplexitySubscores": {
+        "size": 19,
+        "logic": 7.9,
+        "reactive": 10.3,
+        "nesting": 18,
+        "vocabulary": 13.8
+      },
+      "codeComplexityRaw": {
+        "astNodes": 191,
+        "logicDecisions": 2,
+        "reactiveSurface": 5,
+        "maxNestingDepth": 4,
+        "distinctOperators": 21,
+        "distinctOperands": 41,
+        "cssSelectorParts": 0,
+        "directives": 1,
+        "eventHandlers": 0,
+        "bindings": 1,
+        "stateAtoms": 3,
+        "vocabulary": 46
+      }
+    },
+    "react": {
+      "bundleSize": 60.59,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/react",
+        "inlineJsBytes": 3592,
+        "jsRequestCount": 4,
+        "jsRawBytes": 192650,
+        "jsNormalizedBytes": 62042,
+        "jsSources": [
+          {
+            "kind": "inline",
+            "rawBytes": 130,
+            "normalizedBytes": 125
+          },
+          {
+            "kind": "inline",
+            "rawBytes": 3462,
+            "normalizedBytes": 1417
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/ReactNestedCheckboxes.hD1sQuFN.js",
+            "rawBytes": 1036,
+            "normalizedBytes": 512
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/client.BPIbHqJh.js",
+            "rawBytes": 179414,
+            "normalizedBytes": 56476
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/jsx-runtime.D_zvdyIk.js",
+            "rawBytes": 725,
+            "normalizedBytes": 460
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/index.BVOCwoKb.js",
+            "rawBytes": 7883,
+            "normalizedBytes": 3052
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 3592,
+        "jsImplementationNormalizedBytes": 62042,
+        "jsImplementationNormalizedKiB": 60.59,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 58.58,
+      "bundleComponentKiB": 2.01,
+      "bundleSplittable": true,
+      "sourceLines": 72,
+      "codeComplexity": 72,
+      "vibeComplexity": 70,
+      "bundleSizeZScore": 2.395594483978668,
+      "codeComplexityZScore": 1.0469363772830156,
+      "vibeComplexityZScore": 1.2135424717811976,
+      "codeComplexitySubscores": {
+        "size": 20,
+        "logic": 10,
+        "reactive": 14.8,
+        "nesting": 12,
+        "vocabulary": 15.3
+      },
+      "codeComplexityRaw": {
+        "astNodes": 326,
+        "logicDecisions": 3,
+        "reactiveSurface": 12,
+        "maxNestingDepth": 3,
+        "distinctOperators": 38,
+        "distinctOperands": 47,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 3,
+        "bindings": 0,
+        "stateAtoms": 9,
+        "vocabulary": 59
+      }
+    },
+    "svelte": {
+      "bundleSize": 10.82,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/svelte",
+        "inlineJsBytes": 3592,
+        "jsRequestCount": 3,
+        "jsRawBytes": 25195,
+        "jsNormalizedBytes": 11080,
+        "jsSources": [
+          {
+            "kind": "inline",
+            "rawBytes": 130,
+            "normalizedBytes": 125
+          },
+          {
+            "kind": "inline",
+            "rawBytes": 3462,
+            "normalizedBytes": 1417
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/SvelteNestedCheckboxes.DVYpRgRu.js",
+            "rawBytes": 5104,
+            "normalizedBytes": 2547
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/client.svelte.CcUYxmN2.js",
+            "rawBytes": 1125,
+            "normalizedBytes": 621
+          },
+          {
+            "kind": "first-party",
+            "url": "/_astro/render.ClKQ-mU-.js",
+            "rawBytes": 15374,
+            "normalizedBytes": 6370
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 3592,
+        "jsImplementationNormalizedBytes": 11080,
+        "jsImplementationNormalizedKiB": 10.82,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 6.83,
+      "bundleComponentKiB": 3.99,
+      "bundleSplittable": true,
+      "sourceLines": 37,
+      "codeComplexity": 53,
+      "vibeComplexity": 15,
+      "bundleSizeZScore": -0.5200325785410371,
+      "codeComplexityZScore": -0.058163132071278635,
+      "vibeComplexityZScore": -1.3051305828590238,
+      "codeComplexitySubscores": {
+        "size": 18.3,
+        "logic": 10,
+        "reactive": 8,
+        "nesting": 3,
+        "vocabulary": 13.8
+      },
+      "codeComplexityRaw": {
+        "astNodes": 174,
+        "logicDecisions": 3,
+        "reactiveSurface": 3,
+        "maxNestingDepth": 1,
+        "distinctOperators": 24,
+        "distinctOperands": 37,
+        "cssSelectorParts": 0,
+        "directives": 1,
+        "eventHandlers": 0,
+        "bindings": 2,
+        "stateAtoms": 0,
+        "vocabulary": 46
+      }
+    },
+    "hyperscript": {
+      "bundleSize": 24.94,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/hyperscript",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 2,
+        "jsRawBytes": 100869,
+        "jsNormalizedBytes": 25542,
+        "jsSources": [
+          {
+            "kind": "first-party",
+            "url": "/_astro/hyperscript.astro_astro_type_script_index_0_lang.D8yl2yzw.js",
+            "rawBytes": 50,
+            "normalizedBytes": 70
+          },
+          {
+            "kind": "external",
+            "url": "https://unpkg.com/hyperscript.org@0.9.13",
+            "rawBytes": 100819,
+            "normalizedBytes": 25472
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 25542,
+        "jsImplementationNormalizedKiB": 24.94,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 24.88,
+      "bundleComponentKiB": 0.07,
+      "bundleSplittable": true,
+      "sourceLines": 23,
+      "codeComplexity": 24,
+      "vibeComplexity": 48,
+      "bundleSizeZScore": 0.30714552318245564,
+      "codeComplexityZScore": -1.7448939621383592,
+      "vibeComplexityZScore": 0.206073249925109,
+      "codeComplexitySubscores": {
+        "size": 12.5,
+        "logic": 0,
+        "reactive": 4,
+        "nesting": 0,
+        "vocabulary": 7.9
+      },
+      "codeComplexityRaw": {
+        "astNodes": 78,
+        "logicDecisions": 0,
+        "reactiveSurface": 1,
+        "maxNestingDepth": 0,
+        "distinctOperators": 7,
+        "distinctOperands": 11,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 1,
+        "bindings": 0,
+        "stateAtoms": 0,
+        "vocabulary": 16
+      }
+    },
+    "cssOnly": {
+      "bundleSize": 0,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/cssOnly",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 0,
+        "jsRawBytes": 0,
+        "jsNormalizedBytes": 0,
+        "jsSources": [],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 0,
+        "jsImplementationNormalizedKiB": 0,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 0,
+      "bundleComponentKiB": 0,
+      "bundleSplittable": true,
+      "sourceLines": 80,
+      "codeComplexity": 86,
+      "vibeComplexity": 90,
+      "bundleSizeZScore": -1.153890019096858,
+      "codeComplexityZScore": 1.8612202262809163,
+      "vibeComplexityZScore": 2.12942358255946,
+      "codeComplexitySubscores": {
+        "size": 20,
+        "logic": 20,
+        "reactive": 11.2,
+        "nesting": 20,
+        "vocabulary": 14.5
+      },
+      "codeComplexityRaw": {
+        "astNodes": 291,
+        "logicDecisions": 27,
+        "reactiveSurface": 6,
+        "maxNestingDepth": 6,
+        "distinctOperators": 26,
+        "distinctOperands": 46,
+        "cssSelectorParts": 415,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 6,
+        "stateAtoms": 0,
+        "vocabulary": 52
+      }
+    },
+    "jquery": {
+      "bundleSize": 30.84,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/jquery",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 1,
+        "jsRawBytes": 88096,
+        "jsNormalizedBytes": 31576,
+        "jsSources": [
+          {
+            "kind": "first-party",
+            "url": "/_astro/jquery.astro_astro_type_script_index_0_lang.Bc3_QL3Q.js",
+            "rawBytes": 88096,
+            "normalizedBytes": 31576
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 31576,
+        "jsImplementationNormalizedKiB": 30.84,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 30.84,
+      "bundleComponentKiB": 0,
+      "bundleSplittable": false,
+      "sourceLines": 34,
+      "codeComplexity": 43,
+      "vibeComplexity": 35,
+      "bundleSizeZScore": 0.6527794325428385,
+      "codeComplexityZScore": -0.639794452784065,
+      "vibeComplexityZScore": -0.3892494720807615,
+      "codeComplexitySubscores": {
+        "size": 18.4,
+        "logic": 5,
+        "reactive": 0,
+        "nesting": 7,
+        "vocabulary": 12.1
+      },
+      "codeComplexityRaw": {
+        "astNodes": 176,
+        "logicDecisions": 1,
+        "reactiveSurface": 0,
+        "maxNestingDepth": 2,
+        "distinctOperators": 19,
+        "distinctOperands": 28,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 0,
+        "stateAtoms": 0,
+        "vocabulary": 35
+      }
+    },
+    "stimulus": {
+      "bundleSize": 10.87,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/stimulus",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 1,
+        "jsRawBytes": 45459,
+        "jsNormalizedBytes": 11129,
+        "jsSources": [
+          {
+            "kind": "first-party",
+            "url": "/_astro/stimulus.astro_astro_type_script_index_0_lang.BQs1VWcS.js",
+            "rawBytes": 45459,
+            "normalizedBytes": 11129
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 11129,
+        "jsImplementationNormalizedKiB": 10.87,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 10.87,
+      "bundleComponentKiB": 0,
+      "bundleSplittable": false,
+      "sourceLines": 42,
+      "codeComplexity": 48,
+      "vibeComplexity": 52,
+      "bundleSizeZScore": -0.5171034776142542,
+      "codeComplexityZScore": -0.3489787924276718,
+      "vibeComplexityZScore": 0.3892494720807615,
+      "codeComplexitySubscores": {
+        "size": 18.8,
+        "logic": 7.9,
+        "reactive": 0,
+        "nesting": 7,
+        "vocabulary": 14.7
+      },
+      "codeComplexityRaw": {
+        "astNodes": 187,
+        "logicDecisions": 2,
+        "reactiveSurface": 0,
+        "maxNestingDepth": 2,
+        "distinctOperators": 23,
+        "distinctOperands": 46,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 0,
+        "stateAtoms": 0,
+        "vocabulary": 53
+      }
+    },
+    "datastar": {
+      "bundleSize": 12.97,
+      "bundleMeasurement": {
+        "measuredRoute": "/test/datastar",
+        "inlineJsBytes": 0,
+        "jsRequestCount": 1,
+        "jsRawBytes": 34137,
+        "jsNormalizedBytes": 13278,
+        "jsSources": [
+          {
+            "kind": "external",
+            "url": "https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.1/bundles/datastar.js",
+            "rawBytes": 34137,
+            "normalizedBytes": 13278
+          }
+        ],
+        "baselineInlineJsBytes": 0,
+        "baselineNormalizedBytes": 0,
+        "inlineJsImplementationBytes": 0,
+        "jsImplementationNormalizedBytes": 13278,
+        "jsImplementationNormalizedKiB": 12.97,
+        "compressionNote": "Ranked by normalized gzip-compressed JavaScript payload."
+      },
+      "bundleRuntimeKiB": 12.97,
+      "bundleComponentKiB": 0,
+      "bundleSplittable": true,
+      "sourceLines": 25,
+      "codeComplexity": 36,
+      "vibeComplexity": 45,
+      "bundleSizeZScore": -0.3940812386893721,
+      "codeComplexityZScore": -1.0469363772830156,
+      "vibeComplexityZScore": 0.06869108330836968,
+      "codeComplexitySubscores": {
+        "size": 14.1,
+        "logic": 0,
+        "reactive": 12,
+        "nesting": 0,
+        "vocabulary": 9.8
+      },
+      "codeComplexityRaw": {
+        "astNodes": 98,
+        "logicDecisions": 0,
+        "reactiveSurface": 7,
+        "maxNestingDepth": 0,
+        "distinctOperators": 6,
+        "distinctOperands": 19,
+        "cssSelectorParts": 0,
+        "directives": 0,
+        "eventHandlers": 0,
+        "bindings": 5,
+        "stateAtoms": 2,
+        "vocabulary": 23
+      }
+    }
+  }
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,6 +11,7 @@ import StimulusContainer from "../components/stimulus/stimulusContainer.astro";
 import SvelteContainer from "../components/svelte/SvelteContainer.astro";
 import VanillajsContainer from "../components/vanillajs/vanillajsContainer.astro";
 import VueContainer from "../components/vue/vueContainer.astro";
+import BundleCompositionChart from "../components/shared/BundleCompositionChart.astro";
 import { FRAMEWORKS, type FrameworkId } from "../config/frameworks";
 import Layout from "../layouts/Layout.astro";
 
@@ -57,6 +58,7 @@ const frameworks = Object.entries(FRAMEWORKS).map(([id]) => ({
 			))}
 		</div>
 	</div>
+	<BundleCompositionChart />
 	<MetricModal />
 </Layout>
 

--- a/src/types/stats.d.ts
+++ b/src/types/stats.d.ts
@@ -8,6 +8,9 @@ import type {
 export interface FrameworkStats {
 	bundleSize: number;
 	bundleMeasurement: BundleMeasurementAudit;
+	bundleRuntimeKiB: number;
+	bundleComponentKiB: number;
+	bundleSplittable: boolean;
 	sourceLines: number;
 	codeComplexity: number;
 	vibeComplexity: number;

--- a/src/utils/generate-stats.ts
+++ b/src/utils/generate-stats.ts
@@ -10,6 +10,7 @@ import {
 	type JsPayloadMeasurement,
 	buildBundleMeasurementAudit,
 	measureBuiltJsPayload,
+	type JsSourceAudit
 } from "./bundleMeasurement";
 import { calculateStatsZScores } from "./calculateZScores";
 import { analyzeCodeComplexity } from "./code-complexity";
@@ -19,6 +20,46 @@ import { readImplementationSources } from "./implementationSources";
 
 dotenv.config({ path: ".env.local" });
 dotenv.config();
+
+// Frameworks whose npm library is bundled by Astro into the implementation's own
+// chunk, so per-component JS can't be separated from the shared runtime.
+const LIBRARY_BUNDLED_INTO_IMPL = new Set<FrameworkId>(["jquery", "alpine", "stimulus"]);
+
+const implStem = (file: string) =>
+	(file.split("/").pop() ?? file).split(".")[0].toLowerCase();
+
+function classifyBundleSplit(
+	id: FrameworkId,
+	implementationFile: string,
+	sources: JsSourceAudit[],
+): { bundleRuntimeKiB: number; bundleComponentKiB: number; bundleSplittable: boolean } {
+	const stem = implStem(implementationFile);
+	let runtime = 0;
+	let component = 0;
+	for (const s of sources) {
+		// The component's own JS = its inline island bootstrap + its first-party
+		// compiled chunk (matched by the implementation filename stem). Everything
+		// else — renderer, framework runtime, CDN, Astro glue — is shared runtime.
+		// External sources are always runtime (guards the Datastar CDN URL, which
+		// literally contains "datastar").
+		const isComponent =
+			s.kind === "inline" ||
+			(s.kind === "first-party" && (s.url ?? "").toLowerCase().includes(stem));
+		if (isComponent) component += s.normalizedBytes;
+		else runtime += s.normalizedBytes;
+	}
+	const bundleSplittable = !LIBRARY_BUNDLED_INTO_IMPL.has(id);
+	if (!bundleSplittable) {
+		runtime += component; // library fused with impl → attribute the chunk to runtime
+		component = 0;
+	}
+	const KiB = (b: number) => Number((b / 1024).toFixed(2));
+	return {
+		bundleRuntimeKiB: KiB(runtime),
+		bundleComponentKiB: KiB(component),
+		bundleSplittable,
+	};
+}
 
 function calculateMedian(measurements: number[]): number {
 	const sorted = [...measurements].sort((a, b) => a - b);
@@ -125,10 +166,19 @@ async function generateStats(): Promise<void> {
 			`  Code complexity: ${codeComplexityResult.score}/100 (logic decisions ${codeComplexityResult.raw.logicDecisions})`,
 		);
 
+		const split = classifyBundleSplit(
+			id,
+			FRAMEWORKS[id].implementationFile,
+			bundle.bundleMeasurement.jsSources,
+		);
+
 		const source = implementations[id];
 		stats[id] = {
 			bundleSize: bundle.bundleSize,
 			bundleMeasurement: bundle.bundleMeasurement,
+			bundleRuntimeKiB: split.bundleRuntimeKiB,
+			bundleComponentKiB: split.bundleComponentKiB,
+			bundleSplittable: split.bundleSplittable,
 			sourceLines: source.code.split("\n").length,
 			codeComplexity: codeComplexityResult.score,
 			vibeComplexity: 0,


### PR DESCRIPTION
## Bundle composition: runtime vs. per-component

Splits each framework's measured JS bundle into **shared runtime** (paid once) and **per-component JS** (what this one component adds). The split is computed in `generate-stats` from the existing `bundleMeasurement.jsSources` audit and stored as `bundleRuntimeKiB` / `bundleComponentKiB` / `bundleSplittable`, no hardcoded numbers, recomputes on every `pnpm generate-stats`.

### Why this, and not a "cost over N components" chart
The first cut of this PR #104 projected cumulative bundle as you add components. Once I derived the split from the build instead of estimating it, the per-component marginal turned out to be tiny React ~1.9 KiB, Vue ~2.1, Svelte ~3.9
(react-dom alone is 55 of React's 60). A growth projection at that scale would mostly show each framework hugging its fixed runtime; the only way to make it diverge is to assume components much larger than this widget, which the build
can't measure. So this ships the part that's actually measured the composition rather than an extrapolated slope.

### How the split is computed
Each `jsSource` is classified as the component's own JS (its inline island bootstrap + the first-party chunk matching the implementation filename stem) or as shared runtime (renderer, framework runtime, CDN, Astro glue). External
sources are always runtime.

jQuery, Alpine, and Stimulus bundle their library into a single chunk with the implementation, so their per-component JS can't be separated from runtime; they're marked `bundleSplittable: false` and shown entirely as runtime (footnoted in the UI).

### Notes
- The view measures JavaScript only; the UI footnotes that Datastar/Alpine/ Hyperscript move per-component cost into markup this view doesn't count.
- `framework-stats.json` is regenerated and included so the new fields populate and the chart renders on merge; Vibe scores carried over unchanged (no `GEMINI_API_KEY`).