### PR TITLE
feat(ci): GitHub CI, auto-merge, PR-canonical Ship docs

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,27 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - uses: astral-sh/setup-uv@v5
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run check:yaml
+      - run: npm run check:ts
+      - run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,13 +4,15 @@
 
 Ship profile: `vercel-static`
 
+**Integration: branch → PR → CI-gated auto-merge (canonical).** Open a PR from your branch; `.github/workflows/auto-merge.yml` enables squash auto-merge once **`CI / ci`** is green. Direct push to `main` is break-glass only.
+
 Production URL: <https://www.checkboxes.xyz>
 
 Apex `https://checkboxes.xyz` redirects (308) to `https://www.checkboxes.xyz/` — use the www URL for curl/smoke checks and sitemap canonicals.
 
-**Deploy model:** Vercel Git integration deploys production on push to `main`. No local `npm run deploy`, `vercel deploy --prod`, or CLI deploy step.
+**Deploy model:** Vercel Git integration deploys production on merge to `main`. No local `npm run deploy`, `vercel deploy --prod`, or CLI deploy step.
 
-**Local gate before push** (also enforced by `.git-hooks/pre-push` on push to `main`):
+**Local gate before push** (cheap checks; full gate runs in GitHub CI on the PR):
 
 ```shell
 npm ci   # or npm run worktree:init in a worktree


### PR DESCRIPTION
## Summary
- Add GitHub Actions CI + auto-merge workflows
- Update AGENTS.md Ship section: branch → PR → CI-gated auto-merge is canonical
- Direct push to main is break-glass only

## Test plan
- [ ] CI / ci check passes on this PR
- [ ] auto-merge workflow enables squash auto-merge
- [ ] After merge: enable branch protection requiring CI / ci (strict) if not already set

Made with [Cursor](https://cursor.com)