### PR TITLE
Fix CI: vendor fleet tsconfig (no private dotagents clone)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,12 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Checkout dotagents tsconfig baseline
-        uses: actions/checkout@v4
-        with:
-          repository: jsolly/dotagents
-          path: ../dotagents
-          sparse-checkout: tsconfig
       - uses: actions/setup-node@v4
         with:
           node-version-file: .nvmrc

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": [
 		"astro/tsconfigs/strict",
-		"../dotagents/tsconfig/strict-astro.json"
+		"./tsconfig/fleet/strict-astro.json"
 	],
 	"include": [".astro/types.d.ts", "**/*"],
 	"exclude": ["dist"],

--- a/tsconfig/fleet/strict-astro.json
+++ b/tsconfig/fleet/strict-astro.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://json.schemastore.org/tsconfig",
+	"compilerOptions": {
+		"noUncheckedIndexedAccess": true,
+		"noUnusedParameters": true,
+		"noImplicitReturns": true,
+		"noFallthroughCasesInSwitch": true,
+		"noImplicitOverride": true,
+		"allowUnreachableCode": false,
+		"allowUnusedLabels": false
+	}
+}


### PR DESCRIPTION
## Summary
- Vendor tsconfig baseline; drop dotagents clone from CI.

## Test plan
- [ ] CI / ci green

Made with [Cursor](https://cursor.com)