### PR TITLE
style(ui): remove css-only comments and fix code-toggle cursors

### DIFF
--- a/src/components/cssOnly/cssOnly.astro
+++ b/src/components/cssOnly/cssOnly.astro
@@ -9,7 +9,6 @@
 </fieldset>
 
 <style>
-/* Parent toggle is an XOR over the children (CSS can't write `checked`). See cssOnly.md. */
 .checkbox-group {
   --accent: rgb(37 99 235);
   --check: url("data:image/svg+xml,%3csvg viewBox='0 0 16 16' fill='white' xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3e%3c/svg%3e");
@@ -24,7 +23,6 @@
   background: transparent no-repeat center;
 }
 
-/* Rule 1: child looks checked when (parent XOR child) */
 .checkbox-group:has(.parent-checkbox:not(:checked)) .child-checkbox:checked,
 .checkbox-group:has(.parent-checkbox:checked) .child-checkbox:not(:checked) {
   background-color: var(--accent);
@@ -32,7 +30,6 @@
   background-image: var(--check);
 }
 
-/* Rule 2: parent shows CHECK when every child looks checked */
 .checkbox-group:has(.parent-checkbox:not(:checked)):has(.child-checkbox:checked):not(:has(.child-checkbox:not(:checked)))
   .parent-checkbox,
 .checkbox-group:has(.parent-checkbox:checked):not(:has(.child-checkbox:checked))
@@ -42,7 +39,6 @@
   background-image: var(--check);
 }
 
-/* Rule 3: parent shows DASH when children are mixed */
 .checkbox-group:has(.child-checkbox:checked):has(.child-checkbox:not(:checked))
   .parent-checkbox {
   background-color: var(--accent);

--- a/src/components/shared/CodeBlock.astro
+++ b/src/components/shared/CodeBlock.astro
@@ -17,11 +17,11 @@ const codeBlockId = `code-block-${crypto.randomUUID()}`;
 ---
 
 <div
-	class="rounded-b-lg overflow-hidden border-t border-slate-200 mt-2"
+	class="rounded-b-lg overflow-hidden border-t border-slate-200 mt-2 cursor-auto"
 	data-code-block
 >
 	<button 
-		class="w-full bg-slate-50 px-4 py-2 flex items-center justify-between hover:bg-slate-100 transition-colors"
+		class="w-full bg-slate-50 px-4 py-2 flex items-center justify-between hover:bg-slate-100 transition-colors cursor-pointer"
 		data-code-toggle
 		aria-expanded="false"
 		aria-controls={codeBlockId}


### PR DESCRIPTION
## Summary

- Strip the four explainer comments from `cssOnly.astro` — the XOR reasoning already lives in the sibling `cssOnly.md`, so nothing is lost.
- In the shared `CodeBlock.astro`:
  - `cursor-pointer` on the expand/collapse bar (fixes for **all** implementations at once, since it's the shared component).
  - `cursor-auto` on the code region so the open code no longer inherits the drag-reorder grab cursor from its `[data-framework]` card.

No logic changes — purely presentational/comment cleanup.

## Test plan

- [x] `npm run lint` (biome) — clean
- [x] `npm run check:yaml` — clean
- [x] `npm run check:ts` (astro check) — 0 errors, 0 warnings
- [x] `npm run build` — 13 pages built

🤖 Generated with [Claude Code](https://claude.com/claude-code)