### PR TITLE
feat(seo): add page metadata, canonicals, and noindex the test pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -16,7 +16,13 @@ import tailwindcss from "@tailwindcss/vite";
 // https://astro.build/config
 export default defineConfig({
 	site: "https://www.checkboxes.xyz",
-	integrations: [sitemap(), vue(), react(), svelte()],
+	integrations: [
+		// The /test/* routes are noindex demo/measurement pages — keep them out of the sitemap.
+		sitemap({ filter: (page) => !page.includes("/test/") }),
+		vue(),
+		react(),
+		svelte(),
+	],
 	adapter: vercel(),
 	vite: {
 		plugins: [tailwindcss()],

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,7 @@
+# https://www.checkboxes.xyz
+# The /test/* demo pages are intentionally noindex (see Layout.astro); they are left
+# crawlable here so search engines can read the noindex directive and drop them.
+User-agent: *
+Allow: /
+
+Sitemap: https://www.checkboxes.xyz/sitemap-index.xml

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -4,9 +4,18 @@ import "../styles/checkbox-demo.css";
 
 interface Props {
 	title?: string;
+	description?: string;
+	/** When true, the page is excluded from search indexes (used for the /test/* demo pages). */
+	noindex?: boolean;
 }
 
-const { title = "checkboxes.xyz" } = Astro.props;
+const {
+	title = "checkboxes.xyz",
+	description = "A gallery comparing how JavaScript frameworks and CSS-only approaches implement nested parent-child checkboxes, with bundle-size and performance metrics.",
+	noindex = false,
+} = Astro.props;
+
+const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
 <!DOCTYPE html>
@@ -15,7 +24,20 @@ const { title = "checkboxes.xyz" } = Astro.props;
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 		<title>{title}</title>
+		<meta name="description" content={description} />
 		<meta name="theme-color" content="#f8fafc" />
+		<link rel="canonical" href={canonicalURL} />
+		{noindex && <meta name="robots" content="noindex, follow" />}
+
+		<meta property="og:type" content="website" />
+		<meta property="og:site_name" content="checkboxes.xyz" />
+		<meta property="og:title" content={title} />
+		<meta property="og:description" content={description} />
+		<meta property="og:url" content={canonicalURL} />
+
+		<meta name="twitter:card" content="summary" />
+		<meta name="twitter:title" content={title} />
+		<meta name="twitter:description" content={description} />
 	</head>
 	<body>
 		<header class="site-header">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -33,7 +33,10 @@ const frameworks = Object.entries(FRAMEWORKS).map(([id]) => ({
 }));
 ---
 
-<Layout>
+<Layout
+	title="Nested Checkboxes Across 10 JS Frameworks · checkboxes.xyz"
+	description="Compare how 10 JavaScript frameworks and a CSS-only approach implement nested parent-child checkboxes, with side-by-side bundle-size and performance metrics."
+>
 	<div class="min-h-screen p-8 bg-gradient-to-br from-indigo-50 via-white to-purple-50">
 		<div class="max-w-6xl mx-auto mb-12 text-center">
 			<h1 class="text-4xl font-bold text-gray-800 mb-2">Nested Checkboxes</h1>

--- a/src/pages/methodology.astro
+++ b/src/pages/methodology.astro
@@ -3,7 +3,10 @@ import { Content } from "../../METHODOLOGY.md";
 import Layout from "../layouts/Layout.astro";
 ---
 
-<Layout title="Methodology · checkboxes.xyz">
+<Layout
+	title="Methodology · checkboxes.xyz"
+	description="How checkboxes.xyz measures each framework's nested-checkbox implementation — bundle size, dependencies, and the baseline used for comparison."
+>
 	<main class="methodology-prose">
 		<a href="/" class="back-link">← Back to the gallery</a>
 		<Content />

--- a/src/pages/test/[framework].astro
+++ b/src/pages/test/[framework].astro
@@ -27,7 +27,7 @@ if (!isValidFramework(framework)) {
 const frameworkId = framework;
 ---
 
-<Layout title={`${FRAMEWORKS[frameworkId].displayName} Test Page`}>
+<Layout title={`${FRAMEWORKS[frameworkId].displayName} Test Page`} noindex>
 	<div class="min-h-screen p-8">
 		<div
 			class="framework-container"

--- a/src/pages/test/baseline.astro
+++ b/src/pages/test/baseline.astro
@@ -2,7 +2,7 @@
 import Layout from "../../layouts/Layout.astro";
 ---
 
-<Layout title="Baseline Test Page">
+<Layout title="Baseline Test Page" noindex>
 	<div class="min-h-screen p-8">
 		<div class="framework-container" data-framework="baseline">
 		</div>


### PR DESCRIPTION
## Why

An Ahrefs Site Audit (Health Score 100%, but 10 issue types) plus live checks surfaced two systemic gaps:

1. **No `<head>` SEO metadata on any page** — no meta description, canonical link, or Open Graph / Twitter Card tags (the shared `Layout.astro` only emitted charset/viewport/title/theme-color).
2. **The `/test/*` framework pages were indexable** — they exist only for bundle-size measurement (`generate-stats.ts`) and per-framework demos, have no internal links (orphans), and were listed in the sitemap. They also created trailing-slash duplicate URLs (`/methodology` and `/methodology/` both 200) with no canonical to disambiguate.

## What

- **`Layout.astro`**: add `description` + `noindex` props; emit meta description, self-referencing canonical (`new URL(Astro.url.pathname, Astro.site)`), and Open Graph + Twitter Card tags on every page.
- **`index.astro` / `methodology.astro`**: descriptive titles + descriptions (homepage was just `checkboxes.xyz`).
- **`test/[framework].astro`, `test/baseline.astro`**: mark `noindex, follow`.
- **`astro.config.mjs`**: exclude `/test/*` from the sitemap via `sitemap({ filter })`.
- **`public/robots.txt`** (new): allow all, reference `sitemap-index.xml`; `/test/*` left crawlable so search engines can read the `noindex` and drop the pages (a robots `Disallow` would prevent de-indexing).

The self-referencing canonical also resolves the trailing-slash duplicate finding.

## Verification

Built locally and confirmed the emitted output: sitemap now lists only `/` and `/methodology/`; every `/test/*` page emits `noindex, follow`; indexed pages carry canonical + description + OG/Twitter tags. Local gate green: `lint`, `check:yaml`, `check:ts`, `build`, `test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)