### PR TITLE
ci: run npm test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,5 @@ jobs:
       - run: npm run lint
       - run: npm run check:yaml
       - run: npm run check:ts
+      - run: npm test
       - run: npm run build


### PR DESCRIPTION
## Summary

`npm test` (tsx `node:test`, fast, no external services) wasn't run by the pre-push gate or CI. Add it to `ci.yml` between the type check and build so the test suite gates PRs.

## Test plan

- [x] `npm test` green (33 tests)
- [x] Local gate green: lint, yaml, astro check, build

🤖 Generated with [Claude Code](https://claude.com/claude-code)