### PR TITLE
fix: make biome respect gitignore (local/CI parity)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,9 +1,9 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.5.2/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",
-		"useIgnoreFile": false
+		"useIgnoreFile": true
 	},
 	"files": {
 		"ignoreUnknown": true,
@@ -14,14 +14,21 @@
 			"!**/.vercel/**/*",
 			"!**/.astro/**/*",
 			"!**/dist/**/*",
-			"!**/node_modules/**/*"
+			"!**/node_modules/**/*",
+			"!**/.superpowers/**/*"
 		]
 	},
 	"formatter": {
 		"enabled": true,
 		"indentStyle": "tab"
 	},
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
+	"assist": {
+		"actions": {
+			"source": {
+				"organizeImports": "on"
+			}
+		}
+	},
 	"linter": {
 		"enabled": true,
 		"rules": {
@@ -35,7 +42,11 @@
 	},
 	"overrides": [
 		{
-			"includes": ["**/*.svelte", "**/*.astro", "**/*.vue"],
+			"includes": [
+				"**/*.svelte",
+				"**/*.astro",
+				"**/*.vue"
+			],
 			"linter": {
 				"rules": {
 					"style": {


### PR DESCRIPTION
## Summary
- `vcs.useIgnoreFile` was `false`, so a local `.superpowers/` tree (gitignored) failed `npm run lint` while CI (clean checkout) stayed green — the opposite of the usual CI≠local gap, but it forced `-n` during the check:actions rollout.
- Enable `useIgnoreFile`, bump `$schema` to match biome 2.5.3, and exclude `.superpowers` explicitly.

## Test plan
- [x] `npm run lint` passes locally with `.superpowers/` present
- [ ] CI green

Made with [Cursor](https://cursor.com)