### PR TITLE
chore(gate): fail closed on soft warnings

### DIFF
--- a/.git-hooks/pre-commit
+++ b/.git-hooks/pre-commit
@@ -22,7 +22,7 @@ gate_require_node                 # enforce the pinned Node (.nvmrc), not whatev
 
 # --- Quality gate (run_step: silent on green, full output + abort on red) ---
 run_step "dep grounding" gate_check_dep_grounding .git-hooks/pre-commit scripts/*.sh
-run_step "lint"        npm run lint
+run_step "biome ci"     npx --no-install biome ci . --error-on-warnings
 run_step "yaml lint"   npm run check:yaml
 run_step "actionlint"             npm run check:actions
 run_step "astro check (types)" npm run check:ts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: astral-sh/setup-uv@v5
       - run: npm ci
       - run: npm run check:actions
-      - run: npm run lint
+      - run: npx --no-install biome ci . --error-on-warnings
       - run: npm run check:yaml
       - run: npm run check:ts
       - run: npm test

--- a/biome.json
+++ b/biome.json
@@ -42,11 +42,7 @@
 	},
 	"overrides": [
 		{
-			"includes": [
-				"**/*.svelte",
-				"**/*.astro",
-				"**/*.vue"
-			],
+			"includes": ["**/*.svelte", "**/*.astro", "**/*.vue"],
 			"linter": {
 				"rules": {
 					"style": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,10 @@
 		"lint": "biome lint .",
 		"lint-fix": "biome lint --write .",
 		"format": "biome format --write .",
-		"check:biome": "biome check --write .",
+		"check:biome": "biome check --write . --error-on-warnings",
 		"check:ts": "astro check --minimumSeverity warning --minimumFailingSeverity warning",
 		"check:md": "bash scripts/lint-md.sh",
-		"check:yaml": "uvx yamllint@1.38.0 .",
+		"check:yaml": "uvx yamllint@1.38.0 -s .",
 		"generate-stats": "tsx src/utils/generate-stats.ts",
 		"worktree:init": "bash scripts/worktree-init.sh; npm ci",
 		"test": "tsx --test --test-reporter=dot \"tests/**/*.test.ts\"",
@@ -28,7 +28,7 @@
 	"lint-staged": {
 		".agents/**": [],
 		"!(.agents)/**/*": [
-			"biome check --no-errors-on-unmatched --write"
+			"biome check --no-errors-on-unmatched --write --error-on-warnings"
 		]
 	},
 	"overrides": {


### PR DESCRIPTION
## Summary
- Fail closed on soft warnings: `yamllint --strict` (`-s`) and/or `biome ci --error-on-warnings` in local scripts, pre-commit, and CI
- Warning-level findings can no longer exit 0 on the static gate

## Test plan
- [x] Local pre-commit gate green on this branch
- [ ] GitHub CI green on PR


Made with [Cursor](https://cursor.com)