### PR TITLE
fix(ci): label-gate auto-merge on ship-auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,5 +1,11 @@
 name: Auto Merge
 
+# Only PRs labeled ship-auto-merge (added by /ship) get auto-merge — not every open PR.
+# Create the label in GitHub (Settings → Labels) before first use.
+# Job-level label gate: unlabeled PRs skip with ZERO billed runner minutes (label is in
+# the webhook payload — no gh API round-trip). StockTextAlerts uses the same if: on a
+# Blacksmith ARM runner; fleet default is ubuntu-latest.
+
 on:
   pull_request:
     types:
@@ -7,6 +13,7 @@ on:
       - reopened
       - synchronize
       - ready_for_review
+      - labeled
 
 permissions:
   contents: write
@@ -18,10 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'ship-auto-merge')
     steps:
-      - name: Enable auto-merge
+      - name: Enable auto-merge when orchestrated
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
-        run: gh pr merge --auto --squash "$PR_URL"
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr merge --auto --squash --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"


### PR DESCRIPTION
## Summary
- Align `auto-merge.yml` with the fleet template (job-level `ship-auto-merge` label gate)
- Unlabeled PRs skip with zero billed runner minutes

## Test plan
- [ ] Unlabeled PR does not arm auto-merge
- [ ] `/ship` PR with `ship-auto-merge` label arms squash auto-merge when CI is green


Made with [Cursor](https://cursor.com)