### PR TITLE
feat(cursor): install full agent-skills package on cloud VMs

### DIFF
--- a/.cursor/CLOUD.md
+++ b/.cursor/CLOUD.md
@@ -3,21 +3,41 @@
 This file is read by Cloud / Background Agents only (local IDE chat ignores it).
 Repo `AGENTS.md` still applies first; this file overlays cloud-specific facts.
 
-## Skills
+## Public agent-skills package (mirror)
 
-Public fleet skills are installed at `~/.cursor/skills` by `.cursor/install-cloud-skills.sh`
-(via `.cursor/environment.json` `install`). Source: <https://github.com/jsolly/agent-skills>
-(sanitized public mirror — not private `dotagents`).
+`.cursor/install-cloud-skills.sh` (via `.cursor/environment.json` `install`) shallow-clones
+<https://github.com/jsolly/agent-skills> and installs the **full published package**:
+
+| Artifact | VM path | Notes |
+| --- | --- | --- |
+| Skills | `~/.cursor/skills/` | Same discovery as laptop `~/.cursor/skills` |
+| Agents | `~/.cursor/agents/` | One `.md` file per reviewer/scanner agent |
+| Cited rules | `~/.cursor/agent-skills-package/rules/` | **Read from here** when a skill cites `rules/<name>.md` |
+
+Source is the sanitized public mirror — **not** private `~/code/dotagents`.
 
 There is **no** `~/code/dotagents` on this VM. Do not look for it or claim child repos inherit it.
+Do **not** vendor the private dotagents tree into this repo.
 
-If slash-skill autocomplete is empty on a follow-up turn, invoke the skill by name in prose
+`~/.cursor/rules` from a laptop home is **not** auto-applied on cloud. User Rules + repo
+`AGENTS.md` + this file carry policy; skills that cite rules must read the copies under
+`~/.cursor/agent-skills-package/rules/`.
+
+## Laptop-only (not on cloud)
+
+- `scripts/install-local-agent-runtime.sh` and `scripts/doctor-agents.sh`
+- User-level `~/.cursor/hooks.json` and other home hooks/guards
+- Private skills (e.g. `verify-ui`, `publish-skills`, family-memory)
+
+## Skills / slash commands
+
+If slash-skill autocomplete is empty on a **follow-up** turn, invoke the skill by name in prose
 (known Agents Window bug; typed invoke still works).
 
-Private laptop-only skills (e.g. `verify-ui`) are **not** available here. Follow this repo's
-`AGENTS.md` Local UI verification stanza for UI smoke instead of inventing `/verify-ui`.
+Private laptop-only skills are **not** available here. For UI smoke, follow this repo's
+`AGENTS.md` **Local UI verification** stanza — do not invent `/verify-ui` when that skill is absent.
 
 ## Hooks / guards
 
-User-level `~/.cursor/hooks.json` from a laptop does **not** run in cloud. Only hooks committed
-under this repo's `.cursor/hooks.json` (or team/enterprise hooks) apply.
+Only hooks committed under this repo's `.cursor/hooks.json` (or team/enterprise hooks) apply.
+User-level hook config from a laptop does not run in cloud.

--- a/.cursor/install-cloud-skills.sh
+++ b/.cursor/install-cloud-skills.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
-# Install public jsolly/agent-skills into the Cursor Cloud Agent home skills path.
-# Cursor searches /home/ubuntu/.cursor/skills on cloud VMs (forum confirmation 2026-06).
+# Install the full public jsolly/agent-skills package into Cursor Cloud Agent home paths.
+# Skills → ~/.cursor/skills; agents → ~/.cursor/agents; cited rules → ~/.cursor/agent-skills-package/rules
 # Idempotent: safe to re-run from environment.json install/update.
 set -euo pipefail
 
 SKILLS_HOME="${CURSOR_CLOUD_SKILLS_HOME:-${HOME}/.cursor/skills}"
+AGENTS_HOME="${CURSOR_CLOUD_AGENTS_HOME:-${HOME}/.cursor/agents}"
+RULES_HOME="${CURSOR_CLOUD_PACKAGE_RULES:-${HOME}/.cursor/agent-skills-package/rules}"
 MIRROR_URL="${AGENT_SKILLS_MIRROR_URL:-https://github.com/jsolly/agent-skills.git}"
 MIRROR_REF="${AGENT_SKILLS_MIRROR_REF:-main}"
 
@@ -12,29 +14,78 @@ tmpdir="$(mktemp -d)"
 cleanup() { rm -rf "$tmpdir"; }
 trap cleanup EXIT
 
-echo "cloud-skills: cloning ${MIRROR_URL}@${MIRROR_REF} (shallow)"
+echo "cloud-package: cloning ${MIRROR_URL}@${MIRROR_REF} (shallow)"
 git clone --depth 1 --branch "$MIRROR_REF" "$MIRROR_URL" "$tmpdir/agent-skills"
+root="$tmpdir/agent-skills"
 
-src="$tmpdir/agent-skills/skills"
-if [[ ! -d "$src" ]]; then
-  echo "cloud-skills: ERROR — no skills/ directory in mirror checkout" >&2
+# --- skills (required) ---
+src_skills="$root/skills"
+if [[ ! -d "$src_skills" ]]; then
+  echo "cloud-package: ERROR — no skills/ directory in mirror checkout" >&2
   exit 1
 fi
 
 mkdir -p "$SKILLS_HOME"
-installed=0
-for skill_dir in "$src"/*/; do
+installed_skills=0
+for skill_dir in "$src_skills"/*/; do
   [[ -d "$skill_dir" ]] || continue
   name="$(basename "$skill_dir")"
   if [[ ! -f "$skill_dir/SKILL.md" ]]; then
-    echo "cloud-skills: skip ${name} (no SKILL.md)"
+    echo "cloud-package: skip skill ${name} (no SKILL.md)"
     continue
   fi
   dest="$SKILLS_HOME/$name"
   rm -rf "$dest"
   cp -R "$skill_dir" "$dest"
-  installed=$((installed + 1))
-  echo "cloud-skills: installed ${name} → ${dest}"
+  installed_skills=$((installed_skills + 1))
+  echo "cloud-package: installed skill ${name} → ${dest}"
 done
 
-echo "cloud-skills: done (${installed} skill(s) under ${SKILLS_HOME})"
+if [[ "$installed_skills" -eq 0 ]]; then
+  echo "cloud-package: ERROR — no skills installed from mirror" >&2
+  exit 1
+fi
+
+# --- agents (optional during mirror transition) ---
+src_agents="$root/agents"
+installed_agents=0
+if [[ ! -d "$src_agents" ]]; then
+  echo "cloud-package: WARN — no agents/ in mirror; skills only (republish with /publish-skills)" >&2
+else
+  mkdir -p "$AGENTS_HOME"
+  shopt -s nullglob
+  for agent_file in "$src_agents"/*.md; do
+    name="$(basename "$agent_file")"
+    dest="$AGENTS_HOME/$name"
+    cp -f "$agent_file" "$dest"
+    installed_agents=$((installed_agents + 1))
+    echo "cloud-package: installed agent ${name} → ${dest}"
+  done
+  shopt -u nullglob
+  if [[ "$installed_agents" -eq 0 ]]; then
+    echo "cloud-package: WARN — agents/ present but empty; continuing with skills only" >&2
+  fi
+fi
+
+# --- cited rules (optional during mirror transition) ---
+src_rules="$root/rules"
+installed_rules=0
+if [[ ! -d "$src_rules" ]]; then
+  echo "cloud-package: WARN — no rules/ in mirror; read cited rules from republished package later" >&2
+else
+  mkdir -p "$RULES_HOME"
+  shopt -s nullglob
+  for rule_file in "$src_rules"/*.md; do
+    name="$(basename "$rule_file")"
+    dest="$RULES_HOME/$name"
+    cp -f "$rule_file" "$dest"
+    installed_rules=$((installed_rules + 1))
+    echo "cloud-package: installed rule ${name} → ${dest}"
+  done
+  shopt -u nullglob
+  if [[ "$installed_rules" -eq 0 ]]; then
+    echo "cloud-package: WARN — rules/ present but empty; continuing with skills only" >&2
+  fi
+fi
+
+echo "cloud-package: done (${installed_skills} skill(s), ${installed_agents} agent file(s), ${installed_rules} rule file(s))"


### PR DESCRIPTION
## Summary
Thin `.cursor/` copy of installer, CLOUD.md, and environment.json to install the full agent-skills package on cloud VMs.

Made with [Cursor](https://cursor.com)