### PR TITLE
fix(ops): add Vercel Edge Middleware for x-release-id

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,13 @@
+import { next } from "@vercel/edge";
+
+/**
+ * Request-time release id. Astro middleware may not run for fully static routes;
+ * Edge Middleware always runs and reads the deployment SHA.
+ */
+export default function middleware() {
+	const response = next();
+	const sha = process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || "";
+	const releaseId = sha ? sha.slice(0, 12) : "dev";
+	response.headers.set("x-release-id", releaseId);
+	return response;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
 				"@types/alpinejs": "^3.13.11",
 				"@types/react": "^19.0.2",
 				"@types/react-dom": "^19.0.2",
+				"@vercel/edge": "^1.3.1",
 				"alpinejs": "^3.14.8",
 				"astro": "^7.1.3",
 				"dotenv": "^17.4.2",
@@ -5245,6 +5246,12 @@
 			"engines": {
 				"node": ">=14"
 			}
+		},
+		"node_modules/@vercel/edge": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@vercel/edge/-/edge-1.3.1.tgz",
+			"integrity": "sha512-k0tKWeYEWOv6qU6+Z8+hv2Nt/u3vFHRZdB0uvwE0DxoddU/5kWX/Chu8F6ojvqmRlnZwuX/7kyZFVeCP6DxqBg==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@vercel/elysia": {
 			"version": "0.1.102",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
 		"@types/alpinejs": "^3.13.11",
 		"@types/react": "^19.0.2",
 		"@types/react-dom": "^19.0.2",
+		"@vercel/edge": "^1.3.1",
 		"alpinejs": "^3.14.8",
 		"astro": "^7.1.3",
 		"dotenv": "^17.4.2",


### PR DESCRIPTION
## Summary
- Astro middleware alone left production without `x-release-id` on static routes
- Add root Edge Middleware using `VERCEL_GIT_COMMIT_SHA` (same pattern as LTF / jsolly.com)

## Test plan
- [ ] CI green
- [ ] After merge: `curl -sSIL https://www.checkboxes.xyz/ | rg -i '^x-release-id:'` matches `origin/main`


Made with [Cursor](https://cursor.com)