### PR TITLE
chore(ci): bump setup-uv to v8.2.0 (Node 24 Actions)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: npm
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v8.2.0
       - run: npm ci
       - run: npm run check:actions
       - run: npx --no-install biome ci . --error-on-warnings


### PR DESCRIPTION
## Summary
- Drop-in pin of `astral-sh/setup-uv` from `@v5` to `@v8.2.0` in CI for the Node 24 GitHub Actions runtime bump.
- Workflow-only change; no app/runtime deploy impact.

## Test plan
- [x] Local gate: `check:actions`, biome, yaml, ts, test, build
- [ ] CI / ci green on this PR


Made with [Cursor](https://cursor.com)