### PR TITLE
Pass --delete-branch when arming GitHub auto-merge

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -34,4 +34,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: gh pr merge --auto --squash --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"
+        run: gh pr merge --auto --squash --delete-branch --repo "$GITHUB_REPOSITORY" "$PR_NUMBER"


### PR DESCRIPTION
## Summary
- Add `--delete-branch` to `auto-merge.yml` so Actions-armed squash merges delete the head branch. The repo setting does not, when `merged_by` is `github-actions`.

## Test plan
- [ ] CI green
- [ ] After merge, the PR head ref is gone on origin


Made with [Cursor](https://cursor.com)